### PR TITLE
Remove numpy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The miniDB project is a minimal and easy to expand and develop for RMDBS tool, w
 
 Install the two dependencies with the following command:
 ``` Python
-pip install tabulate graphviz numpy
+pip install tabulate graphviz
 ```
 
 Graphviz package is also needed. Linux systems can just do the following:


### PR DESCRIPTION
`numpy` is no longer necessary (see #7).

(actually it never was, since `btree_test.py` is not technically part of miniDB, so you don't quite *intrinsically* "require" `numpy` to use miniDB)