### PR TITLE
Add table size identifier

### DIFF
--- a/preview.py
+++ b/preview.py
@@ -3,22 +3,37 @@ import os
 import sys
 
 def preview(dirname='dbdata', plot=False):
+    plt.figure(figsize=(5, 5))
+
+    table_flag = False
+
     labels = [name for name in os.listdir(dirname) if os.path.isdir(dirname+'/'+name)]
+    if labels == []:
+        labels = [name for name in os.listdir(dirname) if name.endswith('.pkl')]
+        table_flag = True
     sizes = []
 
-    for db in labels:
-        total_size = 0
-        start_path = db
-        for path, dirs, files in os.walk(dirname+'/'+start_path):
-            for f in files:
-                fp = os.path.join(path, f)
-                total_size += os.path.getsize(fp)
-        sizes.append(total_size)
+    if table_flag:
+        for table in labels:
+            total_size = 0
+            start_path = table
+            total_size += os.path.getsize(dirname+'/'+start_path)
+            sizes.append(total_size)
+        labels = [table[:-4] for table in labels]
+        plt.title('Total Table Size Distribution', fontsize=18)
 
-    plt.figure(figsize=(5, 5))
+    else:
+        for db in labels:
+            total_size = 0
+            start_path = db
+            for path, dirs, files in os.walk(dirname+'/'+start_path):
+                for f in files:
+                    fp = os.path.join(path, f)
+                    total_size += os.path.getsize(fp)
+            sizes.append(total_size)
+        plt.title('Total DB Size Distribution', fontsize=18)
+
     plt.pie(sizes, labels=labels, autopct='%1.1f%%', startangle=90, pctdistance=0.85)
-
-    plt.title('Total DB Size Distribution', fontsize=18)
 
     total_db = sum(sizes)
     plt.annotate('Total size', xy=(-0.29, -0.0), size=16, color='darkred')


### PR DESCRIPTION
Now works with both DBs and Tables, detecting which is which automatically and ignoring irrelevant non-`.pkl` files.

Sample result:

![plot](https://user-images.githubusercontent.com/25392776/100477480-1b683d80-30f1-11eb-9db6-0a64bba475a4.png)
