### PR TITLE
Support for ACID-begin-commit-rollback DataStories-UniPi#82 and Not null-Unique constraints DataStories-UniPi#79

### DIFF
--- a/mdb.py
+++ b/mdb.py
@@ -5,10 +5,12 @@ import sys
 import readline
 import traceback
 import shutil
+
 sys.path.append('miniDB')
 
 from database import Database
 from table import Table
+
 # art font is "big"
 art = '''
              _         _  _____   ____  
@@ -17,7 +19,7 @@ art = '''
  | '_ ` _ \ | || '_ \ | || |  | ||  _ < 
  | | | | | || || | | || || |__| || |_) |
  |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2                               
-'''   
+'''
 
 
 def search_between(s, first, last):
@@ -25,17 +27,18 @@ def search_between(s, first, last):
     Search in 's' for the substring that is between 'first' and 'last'
     '''
     try:
-        start = s.index( first ) + len( first )
-        end = s.index( last, start )
+        start = s.index(first) + len(first)
+        end = s.index(last, start)
     except:
         return
     return s[start:end].strip()
+
 
 def in_paren(qsplit, ind):
     '''
     Split string on space and return whether the item in index 'ind' is inside a parentheses
     '''
-    return qsplit[:ind].count('(')>qsplit[:ind].count(')')
+    return qsplit[:ind].count('(') > qsplit[:ind].count(')')
 
 
 def create_query_plan(query, keywords, action):
@@ -45,9 +48,9 @@ def create_query_plan(query, keywords, action):
     This can and will be used recursively
     '''
 
-    dic = {val: None for val in keywords if val!=';'}
+    dic = {val: None for val in keywords if val != ';'}
 
-    ql = [val for val in query.split(' ') if val !='']
+    ql = [val for val in query.split(' ') if val != '']
 
     kw_in_query = []
     kw_positions = []
@@ -55,29 +58,28 @@ def create_query_plan(query, keywords, action):
         if ql[i] in keywords and not in_paren(ql, i):
             kw_in_query.append(ql[i])
             kw_positions.append(i)
-        elif i!=len(ql)-1 and f'{ql[i]} {ql[i+1]}' in keywords and not in_paren(ql, i):
-            kw_in_query.append(f'{ql[i]} {ql[i+1]}')
-            kw_positions.append(i+1)
+        elif i != len(ql) - 1 and f'{ql[i]} {ql[i + 1]}' in keywords and not in_paren(ql, i):
+            kw_in_query.append(f'{ql[i]} {ql[i + 1]}')
+            kw_positions.append(i + 1)
 
+    for i in range(len(kw_in_query) - 1):
+        dic[kw_in_query[i]] = ' '.join(ql[kw_positions[i] + 1:kw_positions[i + 1]])
 
-    for i in range(len(kw_in_query)-1):
-        dic[kw_in_query[i]] = ' '.join(ql[kw_positions[i]+1:kw_positions[i+1]])
-
-    if action=='select':
+    if action == 'select':
         dic = evaluate_from_clause(dic)
-        
+
         if dic['order by'] is not None:
             if 'desc' in dic['order by']:
                 dic['desc'] = True
             else:
                 dic['desc'] = False
             dic['order by'] = dic['order by'].removesuffix(' asc').removesuffix(' desc')
-            
+
         else:
             dic['desc'] = None
 
-    if action=='create table':
-        args = dic['create table'][dic['create table'].index('('):dic['create table'].index(')')+1]
+    if action == 'create table':
+        args = dic['create table'][dic['create table'].index('('):dic['create table'].index(')') + 1]
         dic['create table'] = dic['create table'].removesuffix(args).strip()
         arg_nopk = args.replace('primary key', '')[1:-1]
         arglist = [val.strip().split(' ') for val in arg_nopk.split(',')]
@@ -85,27 +87,26 @@ def create_query_plan(query, keywords, action):
         dic['column_types'] = ','.join([val[1] for val in arglist])
         if 'primary key' in args:
             arglist = args[1:-1].split(' ')
-            dic['primary key'] = arglist[arglist.index('primary')-2]
+            dic['primary key'] = arglist[arglist.index('primary') - 2]
         else:
             dic['primary key'] = None
-    
-    if action=='import': 
-        dic = {'import table' if key=='import' else key: val for key, val in dic.items()}
 
-    if action=='insert into':
+    if action == 'import':
+        dic = {'import table' if key == 'import' else key: val for key, val in dic.items()}
+
+    if action == 'insert into':
         if dic['values'][0] == '(' and dic['values'][-1] == ')':
             dic['values'] = dic['values'][1:-1]
         else:
             raise ValueError('Your parens are not right m8')
-    
-    if action=='unlock table':
+
+    if action == 'unlock table':
         if dic['force'] is not None:
             dic['force'] = True
         else:
             dic['force'] = False
 
     return dic
-
 
 
 def evaluate_from_clause(dic):
@@ -118,20 +119,20 @@ def evaluate_from_clause(dic):
         subquery = ' '.join(from_split[1:-1])
         dic['from'] = interpret(subquery)
 
-    join_idx = [i for i,word in enumerate(from_split) if word=='join' and not in_paren(from_split,i)]
-    on_idx = [i for i,word in enumerate(from_split) if word=='on' and not in_paren(from_split,i)]
+    join_idx = [i for i, word in enumerate(from_split) if word == 'join' and not in_paren(from_split, i)]
+    on_idx = [i for i, word in enumerate(from_split) if word == 'on' and not in_paren(from_split, i)]
     if join_idx:
         join_idx = join_idx[0]
         on_idx = on_idx[0]
         join_dic = {}
-        if from_split[join_idx-1] in join_types:
-            join_dic['join'] = from_split[join_idx-1]
-            join_dic['left'] = ' '.join(from_split[:join_idx-1])
+        if from_split[join_idx - 1] in join_types:
+            join_dic['join'] = from_split[join_idx - 1]
+            join_dic['left'] = ' '.join(from_split[:join_idx - 1])
         else:
             join_dic['join'] = 'inner'
             join_dic['left'] = ' '.join(from_split[:join_idx])
-        join_dic['right'] = ' '.join(from_split[join_idx+1:on_idx])
-        join_dic['on'] = ''.join(from_split[on_idx+1:])
+        join_dic['right'] = ' '.join(from_split[join_idx + 1:on_idx])
+        join_dic['on'] = ''.join(from_split[on_idx + 1:])
 
         if join_dic['left'].startswith('(') and join_dic['left'].endswith(')'):
             join_dic['left'] = interpret(join_dic['left'][1:-1].strip())
@@ -140,8 +141,9 @@ def evaluate_from_clause(dic):
             join_dic['right'] = interpret(join_dic['right'][1:-1].strip())
 
         dic['from'] = join_dic
-        
+
     return dic
+
 
 def interpret(query):
     '''
@@ -162,27 +164,29 @@ def interpret(query):
                      'drop index': ['drop index']
                      }
 
-    if query[-1]!=';':
-        query+=';'
-    
+    if query[-1] != ';':
+        query += ';'
+
     query = query.replace("(", " ( ").replace(")", " ) ").replace(";", " ;").strip()
 
     for kw in kw_per_action.keys():
         if query.startswith(kw):
             action = kw
 
-    return create_query_plan(query, kw_per_action[action]+[';'], action)
+    return create_query_plan(query, kw_per_action[action] + [';'], action)
+
 
 def execute_dic(dic):
     '''
     Execute the given dictionary
     '''
     for key in dic.keys():
-        if isinstance(dic[key],dict):
+        if isinstance(dic[key], dict):
             dic[key] = execute_dic(dic[key])
-    
-    action = list(dic.keys())[0].replace(' ','_')
+
+    action = list(dic.keys())[0].replace(' ', '_')
     return getattr(db, action)(*dic.values())
+
 
 def interpret_meta(command):
     """
@@ -197,19 +201,19 @@ def interpret_meta(command):
     """
     action = command[1:].split(' ')[0].removesuffix(';')
 
-    db_name = db._name if search_between(command, action,';')=='' else search_between(command, action,';')
+    db_name = db._name if search_between(command, action, ';') == '' else search_between(command, action, ';')
 
     def list_databases(db_name):
         [print(fold.removesuffix('_db')) for fold in os.listdir('dbdata')]
-    
+
     def list_tables(db_name):
-        [print(pklf.removesuffix('.pkl')) for pklf in os.listdir(f'dbdata/{db_name}_db') if pklf.endswith('.pkl')\
-            and not pklf.startswith('meta')]
+        [print(pklf.removesuffix('.pkl')) for pklf in os.listdir(f'dbdata/{db_name}_db') if pklf.endswith('.pkl') \
+         and not pklf.startswith('meta')]
 
     def change_db(db_name):
         global db
         db = Database(db_name, load=True)
-    
+
     def remove_db(db_name):
         shutil.rmtree(f'dbdata/{db_name}_db')
 
@@ -223,6 +227,42 @@ def interpret_meta(command):
     commands_dict[action](db_name)
 
 
+def begin_commit_rollback():
+    """
+    This function simulates the begin-commit-rollback functionality of SQL.
+
+    Given that the input is the "begin" keyword, miniDB awaits queries and stores them in the "queries" list.
+    If the user inputs the "commit" keyword, miniDB recursively executes the queries stored in the list.
+    If the user inputs the "rollback" keyword, miniDB exits the begin-commit-rollback state and returns to normal functionality.
+    """
+    queries = []
+    print(
+        "Enter your queries and execute them by typing commit or delete your action by typing rollback once you are done.")
+
+    # If the list isn't empty and while the keywords entered are not rollback or commit or exit, await new input
+    if not queries:
+        query = input()
+        if query[-1] != ";":
+            query += ";"
+        queries.append(query)
+    while queries[-1].lower() != "rollback;" and queries[-1].lower() != "commit;":
+        if queries[-1].lower() == "exit;":
+            print('\nbye!')
+            quit()
+        query = input()
+        if query[-1] != ";":
+            query += ";"
+        queries.append(query)
+
+    # For each query entered by the user execute the query
+    if queries[-1].lower() == "commit;":
+        for query in queries[:-1]:
+            dic = interpret(query)
+            result = execute_dic(dic)
+            if isinstance(result, Table):
+                result.show()
+
+
 if __name__ == "__main__":
     fname = os.getenv('SQL')
     dbname = os.getenv('DB')
@@ -234,7 +274,7 @@ if __name__ == "__main__":
             if line.startswith('--'): continue
             dic = interpret(line.lower())
             result = execute_dic(dic)
-            if isinstance(result,Table):
+            if isinstance(result, Table):
                 result.show()
     else:
         from prompt_toolkit import PromptSession
@@ -246,23 +286,25 @@ if __name__ == "__main__":
         while 1:
             try:
                 line = session.prompt(f'({db._name})> ', auto_suggest=AutoSuggestFromHistory()).lower()
-                if line[-1]!=';':
-                    line+=';'
+                if line[-1] != ';':
+                    line += ';'
             except (KeyboardInterrupt, EOFError):
                 print('\nbye!')
                 break
             try:
-                if line=='exit':
+                if line == "exit;":
                     break
                 if line.startswith('.'):
                     interpret_meta(line)
                 elif line.startswith('explain'):
                     dic = interpret(line.removeprefix('explain '))
                     pprint(dic, sort_dicts=False)
+                elif line.lower() == "begin;":
+                    begin_commit_rollback()
                 else:
                     dic = interpret(line)
                     result = execute_dic(dic)
-                    if isinstance(result,Table):
+                    if isinstance(result, Table):
                         result.show()
             except Exception:
                 print(traceback.format_exc())

--- a/mdb.py
+++ b/mdb.py
@@ -85,6 +85,27 @@ def create_query_plan(query, keywords, action):
         arglist = [val.strip().split(' ') for val in arg_nopk.split(',')]
         dic['column_names'] = ','.join([val[0] for val in arglist])
         dic['column_types'] = ','.join([val[1] for val in arglist])
+        dic['column_constraints'] = ""
+        # If there are any column constraints, it adds them here
+        for i in range(len(arglist)):
+
+            # If there are 3 fields in the create table it appends the dic accordingly
+            # e.g. id int not_null
+            if len(arglist[i]) == 3:
+                if i == 0:
+                    dic['column_constraints'] += (arglist[i][2])
+                else:
+                    dic['column_constraints'] += ','
+                    dic['column_constraints'] += (arglist[i][2])
+
+            # Else if there are 2 fields e.g. id int, it adds the None value to the dic
+            else:
+                if i == 0:
+                    dic['column_constraints'] += 'None'
+                else:
+                    dic['column_constraints'] += ','
+                    dic['column_constraints'] += 'None'
+
         if 'primary key' in args:
             arglist = args[1:-1].split(' ')
             dic['primary key'] = arglist[arglist.index('primary') - 2]
@@ -183,7 +204,6 @@ def execute_dic(dic):
     for key in dic.keys():
         if isinstance(dic[key], dict):
             dic[key] = execute_dic(dic[key])
-
     action = list(dic.keys())[0].replace(' ', '_')
     return getattr(db, action)(*dic.values())
 

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -4,7 +4,6 @@ import pickle
 import os
 from misc import get_op, split_condition
 
-
 """
 
 ISSUES: 
@@ -36,6 +35,7 @@ class Table:
         - a table name (string)
         - column names (list of strings)
         - column types (list of functions like str/int etc)
+        - column constraints(list of constraints like not_null/unique
         - primary (name of the primary key column)
 
     OR
@@ -45,7 +45,9 @@ class Table:
             - a dictionary that includes the appropriate info (all the attributes in __init__)
 
     '''
-    def __init__(self, name=None, column_names=None, column_types=None, primary_key=None, load=None):
+
+    def __init__(self, name=None, column_names=None, column_types=None, column_constraints=None, primary_key=None,
+                 load=None):
 
         if load is not None:
             # if load is a dict, replace the object dict with it (replaces the object with the specified one)
@@ -61,12 +63,12 @@ class Table:
 
             self._name = name
 
-            if len(column_names)!=len(column_types):
+            if len(column_names) != len(column_types):
                 raise ValueError('Need same number of column names and types.')
 
             self.column_names = column_names
-
             self.columns = []
+            self.column_constraints = column_constraints
 
             for col in self.column_names:
                 if col not in self.__dir__():
@@ -78,7 +80,7 @@ class Table:
                     raise Exception(f'"{col}" attribute already exists in "{self.__class__.__name__} "class.')
 
             self.column_types = [eval(ct) if not isinstance(ct, type) else ct for ct in column_types]
-            self.data = [] # data is a list of lists, a list of rows that is.
+            self.data = []  # data is a list of lists, a list of rows that is.
 
             # if primary key is set, keep its index as an attribute
             if primary_key is not None:
@@ -93,7 +95,6 @@ class Table:
 
     def column_by_name(self, column_name):
         return [row[self.column_names.index(column_name)] for row in self.data]
-
 
     def _update(self):
         '''
@@ -120,7 +121,6 @@ class Table:
         self.column_types[column_idx] = cast_type
         # self._update()
 
-
     def _insert(self, row, insert_stack=[]):
         '''
         Insert row to table.
@@ -129,24 +129,52 @@ class Table:
             row: list. A list of values to be inserted (will be casted to a predifined type automatically).
             insert_stack: list. The insert stack (empty by default).
         '''
-        if len(row)!=len(self.column_names):
+        if len(row) != len(self.column_names):
             raise ValueError(f'ERROR -> Cannot insert {len(row)} values. Only {len(self.column_names)} columns exist')
 
         for i in range(len(row)):
-            # for each value, cast and replace it in row.
+            # for each value, cast and replace it in row unless it's an int.
             # try:
-            row[i] = self.column_types[i](row[i])
+            if self.column_types == str:
+                row[i] = self.column_types[i](row[i])
+
+            # If the column constraint's not None
+            if self.column_constraints is not None:
+
+                # If the column's constraint is 'not_null' and the value is '' raise an exception
+                if self.column_constraints[i] == 'not_null':
+                    value = row[i]
+                    value = ''.join(str(value).split())
+                    if not value or value == "''":
+                        print("You can't add a null value into the not null column", self.column_names[i])
+                        raise ValueError("Adding null value in a not null column ")
+
+                # If the value inserted is non-unique and the column has the unique constraint, raise an exception
+                if self.column_constraints[i] == 'unique':
+                    if str(row[i]) in [str(value) for value in self.column_by_name(self.column_names[i])]:
+                        print("You can't add a duplicate value in column", self.column_names[i], "with unique constraint")
+                        raise ValueError("Adding a duplicate value in the unique column")
+                    else:
+                        continue
+
+                # If there is no constraint, add the value
+                if self.column_constraints[i] == 'None':
+                    continue
+
+
+
+
             # except:
             #     raise ValueError(f'ERROR -> Value {row[i]} of type {type(row[i])} is not of type {self.column_types[i]}.')
 
             # if value is to be appended to the primary_key column, check that it doesnt alrady exist (no duplicate primary keys)
-            if i==self.pk_idx and row[i] in self.column_by_name(self.pk):
+            if i == self.pk_idx and row[i] in self.column_by_name(self.pk):
                 raise ValueError(f'## ERROR -> Value {row[i]} already exists in primary key column.')
 
         # if insert_stack is not empty, append to its last index
         if insert_stack != []:
             self.data[insert_stack[-1]] = row
-        else: # else append to the end
+        else:  # else append to the end
             self.data.append(row)
         # self._update()
 
@@ -178,8 +206,7 @@ class Table:
                 self.data[row_ind][set_column_idx] = set_value
 
         # self._update()
-                # print(f"Updated {len(indexes_to_del)} rows")
-
+        # print(f"Updated {len(indexes_to_del)} rows")
 
     def _delete_where(self, condition):
         '''
@@ -219,7 +246,6 @@ class Table:
         # we have to return the deleted indexes, since they will be appended to the insert_stack
         return indexes_to_del
 
-
     def _select_where(self, return_columns, condition=None, order_by=None, desc=True, top_k=None):
         '''
         Select and return a table containing specified columns and rows where condition is met.
@@ -254,21 +280,21 @@ class Table:
         # top k rows
         # rows = rows[:int(top_k)] if isinstance(top_k,str) else rows
         # copy the old dict, but only the rows and columns of data with index in rows/columns (the indexes that we want returned)
-        dict = {(key):([[self.data[i][j] for j in return_cols] for i in rows] if key=="data" else value) for key,value in self.__dict__.items()}
+        dict = {(key): ([[self.data[i][j] for j in return_cols] for i in rows] if key == "data" else value) for
+                key, value in self.__dict__.items()}
 
         # we need to set the new column names/types and no of columns, since we might
         # only return some columns
         dict['column_names'] = [self.column_names[i] for i in return_cols]
-        dict['column_types']   = [self.column_types[i] for i in return_cols]
+        dict['column_types'] = [self.column_types[i] for i in return_cols]
 
-        s_table = Table(load=dict) 
+        s_table = Table(load=dict)
         if order_by:
             s_table.order_by(order_by, desc)
 
-        s_table.data = s_table.data[:int(top_k)] if isinstance(top_k,str) else s_table.data
+        s_table.data = s_table.data[:int(top_k)] if isinstance(top_k, str) else s_table.data
 
         return s_table
-
 
     def _select_where_with_btree(self, return_columns, bt, condition, order_by=None, desc=True, top_k=None):
 
@@ -277,7 +303,6 @@ class Table:
             return_cols = [i for i in range(len(self.column_names))]
         else:
             return_cols = [self.column_names.index(colname) for colname in return_columns]
-
 
         column_name, operator, value = self._parse_condition(condition)
 
@@ -293,7 +318,7 @@ class Table:
         rows1 = []
         opsseq = 0
         for ind, x in enumerate(column):
-            opsseq+=1
+            opsseq += 1
             if get_op(operator, x, value):
                 rows1.append(ind)
 
@@ -303,16 +328,17 @@ class Table:
         # same as simple select from now on
         rows = rows[:top_k]
         # TODO: this needs to be dumbed down
-        dict = {(key):([[self.data[i][j] for j in return_cols] for i in rows] if key=="data" else value) for key,value in self.__dict__.items()}
+        dict = {(key): ([[self.data[i][j] for j in return_cols] for i in rows] if key == "data" else value) for
+                key, value in self.__dict__.items()}
 
         dict['column_names'] = [self.column_names[i] for i in return_cols]
-        dict['column_types']   = [self.column_types[i] for i in return_cols]
+        dict['column_types'] = [self.column_types[i] for i in return_cols]
 
-        s_table = Table(load=dict) 
+        s_table = Table(load=dict)
         if order_by:
             s_table.order_by(order_by, desc)
 
-        s_table.data = s_table.data[:int(top_k)] if isinstance(top_k,str) else s_table.data
+        s_table.data = s_table.data[:int(top_k)] if isinstance(top_k, str) else s_table.data
 
         return s_table
 
@@ -329,7 +355,6 @@ class Table:
         # print(idx)
         self.data = [self.data[i] for i in idx]
         # self._update()
-
 
     def _inner_join(self, table_right: Table, condition):
         '''
@@ -348,23 +373,26 @@ class Table:
         try:
             column_index_left = self.column_names.index(column_name_left)
         except:
-            raise Exception(f'Column "{column_name_left}" dont exist in left table. Valid columns: {self.column_names}.')
+            raise Exception(
+                f'Column "{column_name_left}" dont exist in left table. Valid columns: {self.column_names}.')
 
         try:
             column_index_right = table_right.column_names.index(column_name_right)
         except:
-            raise Exception(f'Column "{column_name_right}" dont exist in right table. Valid columns: {table_right.column_names}.')
+            raise Exception(
+                f'Column "{column_name_right}" dont exist in right table. Valid columns: {table_right.column_names}.')
 
         # get the column names of both tables with the table name in front
         # ex. for left -> name becomes left_table_name_name etc
-        left_names = [f'{self._name}.{colname}' if self._name!='' else colname for colname in self.column_names]
-        right_names = [f'{table_right._name}.{colname}' if table_right._name!='' else colname for colname in table_right.column_names]
+        left_names = [f'{self._name}.{colname}' if self._name != '' else colname for colname in self.column_names]
+        right_names = [f'{table_right._name}.{colname}' if table_right._name != '' else colname for colname in
+                       table_right.column_names]
 
         # define the new tables name, its column names and types
         join_table_name = ''
-        join_table_colnames = left_names+right_names
-        join_table_coltypes = self.column_types+table_right.column_types
-        join_table = Table(name=join_table_name, column_names=join_table_colnames, column_types= join_table_coltypes)
+        join_table_colnames = left_names + right_names
+        join_table_coltypes = self.column_types + table_right.column_types
+        join_table = Table(name=join_table_name, column_names=join_table_colnames, column_types=join_table_coltypes)
 
         # count the number of operations (<,> etc)
         no_of_ops = 0
@@ -374,12 +402,11 @@ class Table:
             left_value = row_left[column_index_left]
             for row_right in table_right.data:
                 right_value = row_right[column_index_right]
-                no_of_ops+=1
-                if get_op(operator, left_value, right_value): #EQ_OP
-                    join_table._insert(row_left+row_right)
+                no_of_ops += 1
+                if get_op(operator, left_value, right_value):  # EQ_OP
+                    join_table._insert(row_left + row_right)
 
         return join_table
-
 
     def show(self, no_of_rows=None, is_locked=False):
         '''
@@ -400,13 +427,12 @@ class Table:
         headers = [f'{col} ({tp.__name__})' for col, tp in zip(self.column_names, self.column_types)]
         if self.pk_idx is not None:
             # table has a primary key, add PK next to the appropriate column
-            headers[self.pk_idx] = headers[self.pk_idx]+' #PK#'
+            headers[self.pk_idx] = headers[self.pk_idx] + ' #PK#'
         # detect the rows that are no tfull of nones (these rows have been deleted)
         # if we dont skip these rows, the returning table has empty rows at the deleted positions
         non_none_rows = [row for row in self.data if any(row)]
         # print using tabulate
-        print(tabulate(non_none_rows[:no_of_rows], headers=headers)+'\n')
-
+        print(tabulate(non_none_rows[:no_of_rows], headers=headers) + '\n')
 
     def _parse_condition(self, condition, join=False):
         '''
@@ -431,7 +457,6 @@ class Table:
         coltype = self.column_types[self.column_names.index(left)]
 
         return left, op, coltype(right)
-
 
     def _load_from_file(self, filename):
         '''


### PR DESCRIPTION
Roxorades: π19187,π19063,π19021

Αναλαβαμε το issues #82 και #79 
Για το #82 υλοποιησαμε την συναρτηση  begin_commit_rollback() στο mdb.py. Αν ο χρηστης εισαγει το keyword begin, τοτε η συναρτηση αναμεινει input απο τον χρηστη και αποθηκευει το input αυτο σε μια ουρα. Αν ο χρηστης εισαγει ως input το keyword commit, τοτε για καθε στοιχειο της ουρας τρεχεται το query ενω αν εισαγει το keyword rollback, η λειτουργεια συνεχιζει κανονικα.
Παρακατω επισυναπτουμε παραδειγματα.

![s2](https://user-images.githubusercontent.com/60107236/152587870-1f9e6e2f-3fbf-4591-9ac2-0cd4716f6623.jpg)

![s3](https://user-images.githubusercontent.com/60107236/152587887-38cd0938-bd8b-40a8-9cbb-a38fe56c168c.jpg)

Για το #79 Αλλαξαμε το mdb.py, το table.py και το database.py. Εισαγαμε ενα εξτρα attribute στο table, το column_constraints, στο οποιο αποθηκευονται τα constraints του καθε column(not_null, unique). Αυτο ειχε ως αποτελεσμα να αλλαξουμε το constructor στο table.py καθως και τις συναρτησεις create_table() και insert() ετσι ωστε να επιτυγχανεται η λειτουργια των παραπανω constraints. Στο database.py αλλαξαμε την συναρτηση create_table() για να δεχεται τα constraints ενω στο mdb.py αλλαξαμε την συναρτηση create_query_plan() ετσι ωστε να δεχεται τα σωστα δεδομενα σε περιπτωση create table.   
Παρακατω επισυναπτουμε παραδειγματα.

![s1](https://user-images.githubusercontent.com/60107236/152588755-ae058f50-e281-45d8-bde2-0fbfb6f1cd30.jpg)

![s4](https://user-images.githubusercontent.com/60107236/152589008-4fd6a7c9-9c7d-4098-aa0a-124ae4c4631e.jpg)
 
Ευχαριστουμε. 