### PR TITLE
Issue #78 & Issue #79

### DIFF
--- a/mdb.py
+++ b/mdb.py
@@ -83,6 +83,8 @@ def create_query_plan(query, keywords, action):
         arglist = [val.strip().split(' ') for val in arg_nopk.split(',')]
         dic['column_names'] = ','.join([val[0] for val in arglist])
         dic['column_types'] = ','.join([val[1] for val in arglist])
+        dic['column_extra'] = ','.join([val[2] if len(val)>=3 else 'none' for val in arglist])
+        print(dic['column_extra'])
         if 'primary key' in args:
             arglist = args[1:-1].split(' ')
             dic['primary key'] = arglist[arglist.index('primary')-2]

--- a/mdb.py
+++ b/mdb.py
@@ -84,8 +84,9 @@ def create_query_plan(query, keywords, action):
         arglist = [val.strip().split(' ') for val in arg_nopk.split(',')]
         dic['column_names'] = ','.join([val[0] for val in arglist])
         dic['column_types'] = ','.join([val[1] for val in arglist])
-        dic['column_extra'] = ','.join([val[2] if len(val)>=3 else 'none' for val in arglist])
-        print(dic['column_extra'])
+        # Extra data to handle types like Not Null,Unique for now and for the other 4 constraints in the feature (FOREIGN CHECK, EXCLUSION
+        dic['column_extra'] = ','.join([" ".join(val[2::]) if len(val)>=3 else 'none' for val in arglist])
+
         if 'primary key' in args:
             arglist = args[1:-1].split(' ')
             dic['primary key'] = arglist[arglist.index('primary')-2]

--- a/mdb.py
+++ b/mdb.py
@@ -11,18 +11,17 @@ from database import Database
 from table import Table
 # art font is "big"
 art = '''
-             _         _  _____   ____  
-            (_)       (_)|  __ \ |  _ \     
+             _         _  _____   ____
+            (_)       (_)|  __ \ |  _ \
   _ __ ___   _  _ __   _ | |  | || |_) |
- | '_ ` _ \ | || '_ \ | || |  | ||  _ < 
+ | '_ ` _ \ | || '_ \ | || |  | ||  _ <
  | | | | | || || | | || || |__| || |_) |
- |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2                               
-'''   
-
-
+ |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2
+'''
 def search_between(s, first, last):
     '''
-    Search in 's' for the substring that is between 'first' and 'last'
+    Search in 's' for the substring that is between 'first'
+    and 'last'
     '''
     try:
         start = s.index( first ) + len( first )
@@ -65,7 +64,7 @@ def create_query_plan(query, keywords, action):
 
     if action=='select':
         dic = evaluate_from_clause(dic)
-        
+
         if dic['order by'] is not None:
             dic['from'] = dic['from'].removesuffix(' order')
             if 'desc' in dic['order by']:
@@ -73,7 +72,7 @@ def create_query_plan(query, keywords, action):
             else:
                 dic['desc'] = False
             dic['order by'] = dic['order by'].removesuffix(' asc').removesuffix(' desc')
-            
+
         else:
             dic['desc'] = None
 
@@ -89,16 +88,20 @@ def create_query_plan(query, keywords, action):
             dic['primary key'] = arglist[arglist.index('primary')-2]
         else:
             dic['primary key'] = None
-    
-    if action=='import': 
+
+    if action=='import':
         dic = {'import table' if key=='import' else key: val for key, val in dic.items()}
 
     if action=='insert into':
         if dic['values'][0] == '(' and dic['values'][-1] == ')':
-            dic['values'] = dic['values'][1:-1]
+                dic['values'] = dic['values'][1:-1]
+                #Calling interpret to precalculate the given "Select" dictionary as value
+                if dic['values'].strip(' ').startswith('select'):
+                    dic['values']=interpret(dic['values'].strip(' '))
+
         else:
             raise ValueError('Your parens are not right m8')
-    
+
     if action=='unlock table':
         if dic['force'] is not None:
             dic['force'] = True
@@ -141,7 +144,7 @@ def evaluate_from_clause(dic):
             join_dic['right'] = interpret(join_dic['right'][1:-1].strip())
 
         dic['from'] = join_dic
-        
+
     return dic
 
 def interpret(query):
@@ -165,7 +168,7 @@ def interpret(query):
 
     if query[-1]!=';':
         query+=';'
-    
+
     query = query.replace("(", " ( ").replace(")", " ) ").replace(";", " ;").strip()
 
     for kw in kw_per_action.keys():
@@ -181,7 +184,7 @@ def execute_dic(dic):
     for key in dic.keys():
         if isinstance(dic[key],dict):
             dic[key] = execute_dic(dic[key])
-    
+
     action = list(dic.keys())[0].replace(' ','_')
     return getattr(db, action)(*dic.values())
 
@@ -202,7 +205,7 @@ def interpret_meta(command):
 
     def list_databases(db_name):
         [print(fold.removesuffix('_db')) for fold in os.listdir('dbdata')]
-    
+
     def list_tables(db_name):
         [print(pklf.removesuffix('.pkl')) for pklf in os.listdir(f'dbdata/{db_name}_db') if pklf.endswith('.pkl')\
             and not pklf.startswith('meta')]
@@ -210,7 +213,7 @@ def interpret_meta(command):
     def change_db(db_name):
         global db
         db = Database(db_name, load=True)
-    
+
     def remove_db(db_name):
         shutil.rmtree(f'dbdata/{db_name}_db')
 

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -47,10 +47,10 @@ class Database:
             pass
 
         # create all the meta tables
-        self.create_table('meta_length', 'table_name,no_of_rows', 'str,int')
-        self.create_table('meta_locks', 'table_name,pid,mode', 'str,int,str')
-        self.create_table('meta_insert_stack', 'table_name,indexes', 'str,list')
-        self.create_table('meta_indexes', 'table_name,index_name', 'str,str')
+        self.create_table('meta_length', 'table_name,no_of_rows', 'str,int', '')
+        self.create_table('meta_locks', 'table_name,pid,mode', 'str,int,str', '')
+        self.create_table('meta_insert_stack', 'table_name,indexes', 'str,list', '')
+        self.create_table('meta_indexes', 'table_name,index_name', 'str,str', '')
         self.save_database()
 
     def save_database(self):
@@ -109,6 +109,7 @@ class Database:
             load: boolean. Defines table object parameters as the name of the table and the column names.
         '''
         # print('here -> ', column_names.split(','))
+        print('here -> ', column_extras.split(','))
         self.tables.update({name: Table(name=name, column_names=column_names.split(','), column_types=column_types.split(','), column_extras=column_extras.split(','), primary_key=primary_key, load=load)})
         # self._name = Table(name=name, column_names=column_names, column_types=column_types, load=load)
         # check that new dynamic var doesnt exist already

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -159,7 +159,7 @@ class Database:
                 colnames = line.strip('\n')
                 if column_types is None:
                     column_types = ",".join(['str' for _ in colnames.split(',')])
-                self.create_table(name=table_name, column_names=colnames, column_types=column_types, primary_key=primary_key)
+                self.create_table(name=table_name, column_names=colnames, column_types=column_types,column_extras='', primary_key=primary_key)
                 lock_ownership = self.lock_table(table_name, mode='x')
                 first_line = False
                 continue

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -268,7 +268,7 @@ class Database:
             self.save_database()
         elif isinstance(ObjData, Table):
             #Checks cause of the way that insert_into function works
-            if len(ObjData.columns) == len(self.tables[table_name].columns):
+            if len(ObjData.column_names) == len(self.tables[table_name].column_names):
                 #Recursively call the insert_into function for each element/row of the returned table
                 [self.insert_into(table_name,','.join(map(str,tmp_data))) for tmp_data in ObjData.data]
             else:

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -109,7 +109,6 @@ class Database:
             load: boolean. Defines table object parameters as the name of the table and the column names.
         '''
         # print('here -> ', column_names.split(','))
-        print('here -> ', column_extras.split(','))
         self.tables.update({name: Table(name=name, column_names=column_names.split(','), column_types=column_types.split(','), column_extras=column_extras.split(','), primary_key=primary_key, load=load)})
         # self._name = Table(name=name, column_names=column_names, column_types=column_types, load=load)
         # check that new dynamic var doesnt exist already

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -97,7 +97,7 @@ class Database:
         self._update_meta_insert_stack()
 
 
-    def create_table(self, name, column_names, column_types, primary_key=None, load=None):
+    def create_table(self, name, column_names, column_types,column_extras, primary_key=None, load=None):
         '''
         This method create a new table. This table is saved and can be accessed via db_object.tables['table_name'] or db_object.table_name
 
@@ -109,7 +109,7 @@ class Database:
             load: boolean. Defines table object parameters as the name of the table and the column names.
         '''
         # print('here -> ', column_names.split(','))
-        self.tables.update({name: Table(name=name, column_names=column_names.split(','), column_types=column_types.split(','), primary_key=primary_key, load=load)})
+        self.tables.update({name: Table(name=name, column_names=column_names.split(','), column_types=column_types.split(','), column_extras=column_extras.split(','), primary_key=primary_key, load=load)})
         # self._name = Table(name=name, column_names=column_names, column_types=column_types, load=load)
         # check that new dynamic var doesnt exist already
         # self.no_of_tables += 1
@@ -267,9 +267,8 @@ class Database:
             self._update()
             self.save_database()
         elif isinstance(ObjData, Table):
-            #Checks cause of the way that insert_into function works 
+            #Checks cause of the way that insert_into function works
             if len(ObjData.columns) == len(self.tables[table_name].columns):
-                #TODO CHECK IF CELLS HAVE SAME DATA TYPE
                 #Recursively call the insert_into function for each element/row of the returned table
                 [self.insert_into(table_name,','.join(map(str,tmp_data))) for tmp_data in ObjData.data]
             else:

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -120,7 +120,7 @@ class Table:
             if i==self.pk_idx and row[i] in self.column_by_name(self.pk):
                 raise ValueError(f'## ERROR -> Value {row[i]} already exists in primary key column.')
             # if value is to be appended to a Not Null Column, check that the value is not null
-            if len(self.column_extras) > i and self.column_extras[i] == "not null" and row[i] == "null":
+            if len(self.column_extras) > i and self.column_extras[i] == "not null" and (row[i] == "null" or row[i] == "") :
                 print(f'## ERROR -> Column {self.column_names[i]} not accepting null values!')
                 raise ValueError(f'## ERROR -> Column {self.column_names[i]} not accepting null values!')
             # if value is to be appended to a Unique Column, check that it doesnt already exist on the specific column data (no duplicate entries)
@@ -146,7 +146,7 @@ class Table:
             condition: string. A condition using the following format:
                 'column[<,<=,=,>=,>]value' or
                 'value[<,<=,=,>=,>]column'.
-                
+
                 Operatores supported: (<,<=,=,>=,>)
         '''
         # parse the condition
@@ -178,7 +178,7 @@ class Table:
             condition: string. A condition using the following format:
                 'column[<,<=,==,>=,>]value' or
                 'value[<,<=,==,>=,>]column'.
-                
+
                 Operatores supported: (<,<=,==,>=,>)
         '''
         column_name, operator, value = self._parse_condition(condition)
@@ -215,7 +215,7 @@ class Table:
             condition: string. A condition using the following format:
                 'column[<,<=,==,>=,>]value' or
                 'value[<,<=,==,>=,>]column'.
-                
+
                 Operatores supported: (<,<=,==,>=,>)
             order_by: string. A column name that signals that the resulting table should be ordered based on it (no order if None).
             desc: boolean. If True, order_by will return results in descending order (False by default).
@@ -247,7 +247,7 @@ class Table:
         dict['column_names'] = [self.column_names[i] for i in return_cols]
         dict['column_types']   = [self.column_types[i] for i in return_cols]
 
-        s_table = Table(load=dict) 
+        s_table = Table(load=dict)
         if order_by:
             s_table.order_by(order_by, desc)
 
@@ -294,7 +294,7 @@ class Table:
         dict['column_names'] = [self.column_names[i] for i in return_cols]
         dict['column_types']   = [self.column_types[i] for i in return_cols]
 
-        s_table = Table(load=dict) 
+        s_table = Table(load=dict)
         if order_by:
             s_table.order_by(order_by, desc)
 
@@ -325,7 +325,7 @@ class Table:
             condition: string. A condition using the following format:
                 'column[<,<=,==,>=,>]value' or
                 'value[<,<=,==,>=,>]column'.
-                
+
                 Operatores supported: (<,<=,==,>=,>)
         '''
         # get columns and operator
@@ -388,6 +388,9 @@ class Table:
         if self.pk_idx is not None:
             # table has a primary key, add PK next to the appropriate column
             headers[self.pk_idx] = headers[self.pk_idx]+' #PK#'
+        for i in range (len(self.column_extras)):
+            if self.column_extras[i] != "none":
+                headers[i] = headers[i] + f' #{self.column_extras[i].upper()}#'
         # detect the rows that are no tfull of nones (these rows have been deleted)
         # if we dont skip these rows, the returning table has empty rows at the deleted positions
         non_none_rows = [row for row in self.data if any(row)]
@@ -403,7 +406,7 @@ class Table:
             condition: string. A condition using the following format:
                 'column[<,<=,==,>=,>]value' or
                 'value[<,<=,==,>=,>]column'.
-                
+
                 Operatores supported: (<,<=,==,>=,>)
             join: boolean. Whether to join or not (False by default).
         '''

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -22,7 +22,7 @@ class Table:
             - a dictionary that includes the appropriate info (all the attributes in __init__)
 
     '''
-    def __init__(self, name=None, column_names=None, column_types=None, primary_key=None, load=None):
+    def __init__(self, name=None, column_names=None, column_types=None,column_extras=None, primary_key=None, load=None):
 
         if load is not None:
             # if load is a dict, replace the object dict with it (replaces the object with the specified one)
@@ -42,6 +42,7 @@ class Table:
                 raise ValueError('Need same number of column names and types.')
 
             self.column_names = column_names
+            self.column_extras = column_extras
 
             self.columns = []
 

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -62,6 +62,18 @@ class Table:
                 self.pk_idx = self.column_names.index(primary_key)
             else:
                 self.pk_idx = None
+            #if not null colums are set , keep their indexes as attribute
+            if column_extras is not None:
+                self.not_null_columns_idx = [self.column_extras.index(col) for col in column_extras if col == "not null"]
+            else:
+                self.not_null_columns_idx = []
+
+            #if unique colums are set , keep their indexes as attribute
+            if column_extras is not None:
+                self.unique_columns_idx = [self.column_extras.index(col) for col in column_extras if col == "unique"]
+            else:
+                self.unique_columns_idx = []
+
 
             self.pk = primary_key
             # self._update()
@@ -120,11 +132,11 @@ class Table:
             if i==self.pk_idx and row[i] in self.column_by_name(self.pk):
                 raise ValueError(f'## ERROR -> Value {row[i]} already exists in primary key column.')
             # if value is to be appended to a Not Null Column, check that the value is not null
-            if len(self.column_extras) > i and self.column_extras[i] == "not null" and (row[i] == "null" or row[i] == "") :
+            if i in self.not_null_columns_idx and (row[i] == "null" or row[i] == "") :
                 print(f'## ERROR -> Column {self.column_names[i]} not accepting null values!')
                 raise ValueError(f'## ERROR -> Column {self.column_names[i]} not accepting null values!')
             # if value is to be appended to a Unique Column, check that it doesnt already exist on the specific column data (no duplicate entries)
-            if len(self.column_extras) > i and self.column_extras[i] == "unique" and row[i] in self.column_by_name(self.column_names[i]):
+            if i in self.unique_columns_idx and row[i] in self.column_by_name(self.column_names[i]):
                 print(f'## ERROR -> Value {row[i]} already exists in the specific column')
                 raise ValueError(f'## ERROR -> Value {row[i]} already exists in the specific column')
 

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -22,8 +22,7 @@ class Table:
             - a dictionary that includes the appropriate info (all the attributes in __init__)
 
     '''
-    def __init__(self, name=None, column_names=None, column_types=None,column_extras=None, primary_key=None, load=None):
-
+    def __init__(self, name=None, column_names=None, column_types=None, column_extras=None, primary_key=None, load=None):
         if load is not None:
             # if load is a dict, replace the object dict with it (replaces the object with the specified one)
             if isinstance(load, dict):
@@ -34,7 +33,7 @@ class Table:
                 self._load_from_file(load)
 
         # if name, columns_names and column types are not none
-        elif (name is not None) and (column_names is not None) and (column_types is not None):
+        elif (name is not None) and (column_names is not None) and (column_types is not None) and (column_extras is not None):
 
             self._name = name
 
@@ -117,9 +116,18 @@ class Table:
             # except:
             #     raise ValueError(f'ERROR -> Value {row[i]} of type {type(row[i])} is not of type {self.column_types[i]}.')
 
-            # if value is to be appended to the primary_key column, check that it doesnt alrady exist (no duplicate primary keys)
+            # if value is to be appended to the primary_key column, check that it doesnt already exist (no duplicate primary keys)
             if i==self.pk_idx and row[i] in self.column_by_name(self.pk):
                 raise ValueError(f'## ERROR -> Value {row[i]} already exists in primary key column.')
+            # if value is to be appended to a Not Null Column, check that the value is not null
+            if len(self.column_extras) > i and self.column_extras[i] == "not null" and row[i] == "null":
+                print(f'## ERROR -> Column {self.column_names[i]} not accepting null values!')
+                raise ValueError(f'## ERROR -> Column {self.column_names[i]} not accepting null values!')
+            # if value is to be appended to a Unique Column, check that it doesnt already exist on the specific column data (no duplicate entries)
+            if len(self.column_extras) > i and self.column_extras[i] == "unique" and row[i] in self.column_by_name(self.column_names[i]):
+                print(f'## ERROR -> Value {row[i]} already exists in the specific column')
+                raise ValueError(f'## ERROR -> Value {row[i]} already exists in the specific column')
+
 
         # if insert_stack is not empty, append to its last index
         if insert_stack != []:
@@ -342,7 +350,8 @@ class Table:
         join_table_name = ''
         join_table_colnames = left_names+right_names
         join_table_coltypes = self.column_types+table_right.column_types
-        join_table = Table(name=join_table_name, column_names=join_table_colnames, column_types= join_table_coltypes)
+        join_table_extras = self.column_extras+table_right.column_extras
+        join_table = Table(name=join_table_name, column_names=join_table_colnames, column_types= join_table_coltypes, column_extras= join_table_extras)
 
         # count the number of operations (<,> etc)
         no_of_ops = 0

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -64,13 +64,13 @@ class Table:
                 self.pk_idx = None
             #if not null colums are set , keep their indexes as attribute
             if column_extras is not None:
-                self.not_null_columns_idx = [self.column_extras.index(col) for col in column_extras if col == "not null"]
+                self.not_null_columns_idx = [index for index in range(len(column_extras)) if column_extras[index] == "not null"]
             else:
                 self.not_null_columns_idx = []
 
             #if unique colums are set , keep their indexes as attribute
             if column_extras is not None:
-                self.unique_columns_idx = [self.column_extras.index(col) for col in column_extras if col == "unique"]
+                self.unique_columns_idx = [index for index in range(len(column_extras)) if column_extras[index] == "unique"]
             else:
                 self.unique_columns_idx = []
 
@@ -127,9 +127,9 @@ class Table:
             row[i] = self.column_types[i](row[i])
             # except:
             #     raise ValueError(f'ERROR -> Value {row[i]} of type {type(row[i])} is not of type {self.column_types[i]}.')
-
             # if value is to be appended to the primary_key column, check that it doesnt already exist (no duplicate primary keys)
             if i==self.pk_idx and row[i] in self.column_by_name(self.pk):
+                print(f'## ERROR -> Value {row[i]} already exists in primary key column.')
                 raise ValueError(f'## ERROR -> Value {row[i]} already exists in primary key column.')
             # if value is to be appended to a Not Null Column, check that the value is not null
             if i in self.not_null_columns_idx and (row[i] == "null" or row[i] == "") :


### PR DESCRIPTION
# INSERT INTO table SELECT … - 30/50 #78  
### Υλοποιήθηκε η υποστήριξη πολλαπλών rows για την εντολή INSERT INTO με την χρήση select.
> INSERT INTO table VALUES (SELECT * FROM table)

## Ποιο αναλυτικά
Προστέθηκε η υποστήριξη της **SELECT** ως όρισμα στα values της **INSERT INTO**. Στο αρχείο [mdb.py](https://github.com/CyberGl1tch/miniDB/blob/dev/mdb.py) στο action “insert into” ελέγχεται αν η τιμή που δίνεται στο κλειδί values αν ξεκινάει με select.
Στην περίπτωση που ικανοποιείται η συνθήκη τότε καλείτε η συνάρτηση interpret() με όρισμα το query command που υπάρχει ως τιμή στο [κλειδί values](https://github.com/CyberGl1tch/miniDB/blob/9d6b939da21ee9f9a1eb5ef0412aa68e30e8ad90/mdb.py#L99-L107). Από εκεί και ύστερα η interpret() θα ελέγξει την ορθή σύνταξη της εντολής σε περίπτωση που ο χρήστης την γράψει λάθος.

Στην συνεχεία στο αρχείο database.py τροποποιήθηκε και η συνάρτηση [insert_into()](https://github.com/CyberGl1tch/miniDB/blob/9d6b939da21ee9f9a1eb5ef0412aa68e30e8ad90/miniDB/database.py#L251-L275) να μπορεί να δέχεται ως παράμετρο το αντικείμενο που επιστρέφει το SELECT query. [Ελέγχοντας](https://github.com/CyberGl1tch/miniDB/blob/9d6b939da21ee9f9a1eb5ef0412aa68e30e8ad90/miniDB/database.py#L269) αν η παράμετρος ObjData ειναι instance του table στην συνέχεια [ελέγχει](https://github.com/CyberGl1tch/miniDB/blob/9d6b939da21ee9f9a1eb5ef0412aa68e30e8ad90/miniDB/database.py#L271-L273) αν το σύνολο των στοιχείων στην ιδιότητα columns_names του αντικειμένου που επιστρέφετε είναι ίσο με τα columns_names του table που θέλουμε να κάνουμε insert. Εφόσον ικανοποιείται η συνθήκη εισάγουμε τα δεδομένα από κάθε column που επιστρέφονται, με αναδρομικό τρόπο. 

## Παραδείγματα
Παράδειγμα δυο tables το πρώτο citizens που είναι κενό και το δεύτερο citizens2 με 500 entries
>![showcase2dbforselct](https://user-images.githubusercontent.com/28480818/152600057-98cd3b8b-5a35-48a4-9a01-391823f86ac9.png)

Μόλις εκτέσουμε το query 
> NSERT INTO citizens VALUES(SELECT * FROM citizens2) 
![insert select into](https://user-images.githubusercontent.com/28480818/152600189-5b5a9bfa-2dd4-4057-b0d0-5f12debc6b65.png)

## Related Commits
https://github.com/DataStories-UniPi/miniDB/commit/43f5c0cef422d513b78f4de7ad52d1f52220dd41
https://github.com/CyberGl1tch/miniDB/commit/99e9f9a7ad9d2f5fdc5a7dd271c50dc47c8d3861
https://github.com/DataStories-UniPi/miniDB/commit/ae5da5832a5813b10e81c16bce0e92d486d36896
https://github.com/CyberGl1tch/miniDB/commit/517a059b100c51d412f7ab8e7881bcfb77e154e5

# NOT NULL, UNIQUE constraints (+ Btree functionality) #79
> INSERT INTO table VALUES (SELECT * FROM table)

## Ποιο αναλυτικά
Τροποποιήθηκε η συνάρτηση [create_table()](https://github.com/CyberGl1tch/miniDB/blob/9d6b939da21ee9f9a1eb5ef0412aa68e30e8ad90/miniDB/database.py#L100) να δέχεται παραμέτρους για τα το κάθε column στο αρχείο database.py . Στο αρχείο table.py προστέθηκε η ιδιότητα [columns_extras](https://github.com/CyberGl1tch/miniDB/blob/9d6b939da21ee9f9a1eb5ef0412aa68e30e8ad90/miniDB/table.py#L25). Προκειμένου το table της βάσης να γνωρίζει ποια από τα columns είναι UNIQUE ή NOT NULL. Αναπτύχθηκε η ιδιότητα 
[not_null_columns_idx](https://github.com/CyberGl1tch/miniDB/blob/9d6b939da21ee9f9a1eb5ef0412aa68e30e8ad90/miniDB/table.py#L124-L141), η λίστα θα αποθηκεύει τα indexes των columns που έχουν κάποιο από τα παραπάνω constraints.

## Παραδείγματα
Για την εντολή
>CREATE TABLE citizens(id int PRIMARY KEY,firstname str NOT NULL,lastname str NOT NULL,email str UNIQUE)
>![contrains tag](https://user-images.githubusercontent.com/28480818/152605054-deadbb14-5efe-41a5-8ebe-516444e4005c.png)


Παρακάτω στο table citizens υπάρχει το entry
>![select db](https://user-images.githubusercontent.com/28480818/152606642-c5d4c2e6-d089-4859-9908-699908afd4c1.png)

Eφόσον υπάρχει ήδη στην βάση το column firstname Elmore , lastname Hemphil και Address 1 blackbird lane δεν το εισάγει και εμφανίζει μήνυμα λάθους.
>INSERT INTO citizens VALUES(502,Elmore,Hemphill, 1 Blackbird Lane) 
![unique](https://user-images.githubusercontent.com/28480818/152606882-702e4066-2849-4f57-bfc8-77691a08dd46.png)

Αντίστοιχα αν προσπαθήσει ο χρηστής να εισάγει entry με null τιμή
>![null](https://user-images.githubusercontent.com/28480818/152611354-c8c01b9c-695b-46ec-afe4-ba0a0bbca90f.png)

## Related Commits
https://github.com/CyberGl1tch/miniDB/commit/6ec82f902a1ca5eeb9cc667dfdcae6a08fcdb191
https://github.com/CyberGl1tch/miniDB/commit/6c46e640f9f639020810ce818ea92ab6e874ff3b
https://github.com/CyberGl1tch/miniDB/commit/55fd4054d1806da1959e608c68616259a7e32996
https://github.com/CyberGl1tch/miniDB/commit/d2ffbf9139c777c9b4228ab199929f14100c7761
https://github.com/CyberGl1tch/miniDB/commit/9d6b939da21ee9f9a1eb5ef0412aa68e30e8ad90

## Ομάδα JK
- Ιωάννης Πλυτάς Π19142
- Κωνσταντίνος Μαυρέλης Π19101