### PR TITLE
Create temp view and join processing (Prolog fight team)

### DIFF
--- a/mdb.py
+++ b/mdb.py
@@ -119,8 +119,8 @@ def evaluate_from_clause(dic):
         subquery = ' '.join(from_split[1:-1])
         dic['from'] = interpret(subquery)
 
-    join_idx = [i for i,word in enumerate(from_split) if word=='join' and not in_paren(from_split,i)]
-    on_idx = [i for i,word in enumerate(from_split) if word=='on' and not in_paren(from_split,i)]
+    join_idx = [i for i, word in enumerate(from_split) if word == 'join' and not in_paren(from_split, i)]
+    on_idx = [i for i, word in enumerate(from_split) if word == 'on' and not in_paren(from_split, i)]
     if join_idx:
         join_idx = join_idx[0]
         on_idx = on_idx[0]
@@ -161,12 +161,12 @@ def interpret(query):
                      'update table': ['update table', 'set', 'where'],
                      'create index': ['create index', 'on', 'using'],
                      'drop index': ['drop index'],
-                     'create view': ['create view','on'],
+                     'create view': ['create view', 'on', 'select'],
                      'drop view': ['drop view']
                      }
 
-    if query[-1]!=';':
-        query+=';'
+    if query[-1] != ';':
+        query += ';'
     
     query = query.replace("(", " ( ").replace(")", " ) ").replace(";", " ;").strip()
 

--- a/mdb.py
+++ b/mdb.py
@@ -5,10 +5,11 @@ import sys
 import readline
 import traceback
 import shutil
+##from table import Table
 sys.path.append('miniDB')
 
-from database import Database
-from table import Table
+##from database import Database
+
 # art font is "big"
 art = '''
              _         _  _____   ____  
@@ -17,7 +18,7 @@ art = '''
  | '_ ` _ \ | || '_ \ | || |  | ||  _ < 
  | | | | | || || | | || || |__| || |_) |
  |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2                               
-'''   
+'''
 
 
 def search_between(s, first, last):
@@ -25,17 +26,18 @@ def search_between(s, first, last):
     Search in 's' for the substring that is between 'first' and 'last'
     '''
     try:
-        start = s.index( first ) + len( first )
-        end = s.index( last, start )
+        start = s.index(first) + len(first)
+        end = s.index(last, start)
     except:
         return
     return s[start:end].strip()
+
 
 def in_paren(qsplit, ind):
     '''
     Split string on space and return whether the item in index 'ind' is inside a parentheses
     '''
-    return qsplit[:ind].count('(')>qsplit[:ind].count(')')
+    return qsplit[:ind].count('(') > qsplit[:ind].count(')')
 
 
 def create_query_plan(query, keywords, action):
@@ -45,9 +47,9 @@ def create_query_plan(query, keywords, action):
     This can and will be used recursively
     '''
 
-    dic = {val: None for val in keywords if val!=';'}
+    dic = {val: None for val in keywords if val != ';'}
 
-    ql = [val for val in query.split(' ') if val !='']
+    ql = [val for val in query.split(' ') if val != '']
 
     kw_in_query = []
     kw_positions = []
@@ -55,17 +57,16 @@ def create_query_plan(query, keywords, action):
         if ql[i] in keywords and not in_paren(ql, i):
             kw_in_query.append(ql[i])
             kw_positions.append(i)
-        elif i!=len(ql)-1 and f'{ql[i]} {ql[i+1]}' in keywords and not in_paren(ql, i):
-            kw_in_query.append(f'{ql[i]} {ql[i+1]}')
-            kw_positions.append(i+1)
+        elif i != len(ql) - 1 and f'{ql[i]} {ql[i + 1]}' in keywords and not in_paren(ql, i):
+            kw_in_query.append(f'{ql[i]} {ql[i + 1]}')
+            kw_positions.append(i + 1)
 
+    for i in range(len(kw_in_query) - 1):
+        dic[kw_in_query[i]] = ' '.join(ql[kw_positions[i] + 1:kw_positions[i + 1]])
 
-    for i in range(len(kw_in_query)-1):
-        dic[kw_in_query[i]] = ' '.join(ql[kw_positions[i]+1:kw_positions[i+1]])
-
-    if action=='select':
+    if action == 'select':
         dic = evaluate_from_clause(dic)
-        
+
         if dic['order by'] is not None:
             dic['from'] = dic['from'].removesuffix(' order')
             if 'desc' in dic['order by']:
@@ -73,12 +74,12 @@ def create_query_plan(query, keywords, action):
             else:
                 dic['desc'] = False
             dic['order by'] = dic['order by'].removesuffix(' asc').removesuffix(' desc')
-            
+
         else:
             dic['desc'] = None
 
-    if action=='create table':
-        args = dic['create table'][dic['create table'].index('('):dic['create table'].index(')')+1]
+    if action == 'create table':
+        args = dic['create table'][dic['create table'].index('('):dic['create table'].index(')') + 1]
         dic['create table'] = dic['create table'].removesuffix(args).strip()
         arg_nopk = args.replace('primary key', '')[1:-1]
         arglist = [val.strip().split(' ') for val in arg_nopk.split(',')]
@@ -86,20 +87,20 @@ def create_query_plan(query, keywords, action):
         dic['column_types'] = ','.join([val[1] for val in arglist])
         if 'primary key' in args:
             arglist = args[1:-1].split(' ')
-            dic['primary key'] = arglist[arglist.index('primary')-2]
+            dic['primary key'] = arglist[arglist.index('primary') - 2]
         else:
             dic['primary key'] = None
-    
-    if action=='import': 
-        dic = {'import table' if key=='import' else key: val for key, val in dic.items()}
 
-    if action=='insert into':
+    if action == 'import':
+        dic = {'import table' if key == 'import' else key: val for key, val in dic.items()}
+
+    if action == 'insert into':
         if dic['values'][0] == '(' and dic['values'][-1] == ')':
             dic['values'] = dic['values'][1:-1]
         else:
             raise ValueError('Your parens are not right m8')
-    
-    if action=='unlock table':
+
+    if action == 'unlock table':
         if dic['force'] is not None:
             dic['force'] = True
         else:
@@ -108,12 +109,11 @@ def create_query_plan(query, keywords, action):
     return dic
 
 
-
 def evaluate_from_clause(dic):
     '''
     Evaluate the part of the query (argument or subquery) that is supplied as the 'from' argument
     '''
-    join_types = ['inner', 'left', 'right', 'full']
+    join_types = ['inner', 'left', 'right', 'full', 'smj', 'inlj']
     from_split = dic['from'].split(' ')
     if from_split[0] == '(' and from_split[-1] == ')':
         subquery = ' '.join(from_split[1:-1])
@@ -125,14 +125,14 @@ def evaluate_from_clause(dic):
         join_idx = join_idx[0]
         on_idx = on_idx[0]
         join_dic = {}
-        if from_split[join_idx-1] in join_types:
-            join_dic['join'] = from_split[join_idx-1]
-            join_dic['left'] = ' '.join(from_split[:join_idx-1])
+        if from_split[join_idx - 1] in join_types:
+            join_dic['join'] = from_split[join_idx - 1]
+            join_dic['left'] = ' '.join(from_split[:join_idx - 1])
         else:
             join_dic['join'] = 'inner'
             join_dic['left'] = ' '.join(from_split[:join_idx])
-        join_dic['right'] = ' '.join(from_split[join_idx+1:on_idx])
-        join_dic['on'] = ''.join(from_split[on_idx+1:])
+        join_dic['right'] = ' '.join(from_split[join_idx + 1:on_idx])
+        join_dic['on'] = ''.join(from_split[on_idx + 1:])
 
         if join_dic['left'].startswith('(') and join_dic['left'].endswith(')'):
             join_dic['left'] = interpret(join_dic['left'][1:-1].strip())
@@ -141,8 +141,9 @@ def evaluate_from_clause(dic):
             join_dic['right'] = interpret(join_dic['right'][1:-1].strip())
 
         dic['from'] = join_dic
-        
+
     return dic
+
 
 def interpret(query):
     '''
@@ -167,25 +168,27 @@ def interpret(query):
 
     if query[-1] != ';':
         query += ';'
-    
+
     query = query.replace("(", " ( ").replace(")", " ) ").replace(";", " ;").strip()
 
     for kw in kw_per_action.keys():
         if query.startswith(kw):
             action = kw
 
-    return create_query_plan(query, kw_per_action[action]+[';'], action)
+    return create_query_plan(query, kw_per_action[action] + [';'], action)
+
 
 def execute_dic(dic):
     '''
     Execute the given dictionary
     '''
     for key in dic.keys():
-        if isinstance(dic[key],dict):
+        if isinstance(dic[key], dict):
             dic[key] = execute_dic(dic[key])
-    
-    action = list(dic.keys())[0].replace(' ','_')
+
+    action = list(dic.keys())[0].replace(' ', '_')
     return getattr(db, action)(*dic.values())
+
 
 def interpret_meta(command):
     """
@@ -200,19 +203,19 @@ def interpret_meta(command):
     """
     action = command[1:].split(' ')[0].removesuffix(';')
 
-    db_name = db._name if search_between(command, action,';')=='' else search_between(command, action,';')
+    db_name = db._name if search_between(command, action, ';') == '' else search_between(command, action, ';')
 
     def list_databases(db_name):
         [print(fold.removesuffix('_db')) for fold in os.listdir('dbdata')]
-    
+
     def list_tables(db_name):
-        [print(pklf.removesuffix('.pkl')) for pklf in os.listdir(f'dbdata/{db_name}_db') if pklf.endswith('.pkl')\
-            and not pklf.startswith('meta')]
+        [print(pklf.removesuffix('.pkl')) for pklf in os.listdir(f'dbdata/{db_name}_db') if pklf.endswith('.pkl') \
+         and not pklf.startswith('meta')]
 
     def change_db(db_name):
         global db
         db = Database(db_name, load=True)
-    
+
     def remove_db(db_name):
         shutil.rmtree(f'dbdata/{db_name}_db')
 
@@ -230,14 +233,14 @@ if __name__ == "__main__":
     fname = os.getenv('SQL')
     dbname = os.getenv('DB')
 
-    db = Database(dbname, load=True)
+    ## db = Database(dbname, load=True)
 
     if fname is not None:
         for line in open(fname, 'r').read().splitlines():
             if line.startswith('--'): continue
             dic = interpret(line.lower())
             result = execute_dic(dic)
-            if isinstance(result,Table):
+            if isinstance(result, Table):
                 result.show()
     else:
         from prompt_toolkit import PromptSession
@@ -249,13 +252,13 @@ if __name__ == "__main__":
         while 1:
             try:
                 line = session.prompt(f'({db._name})> ', auto_suggest=AutoSuggestFromHistory()).lower()
-                if line[-1]!=';':
-                    line+=';'
+                if line[-1] != ';':
+                    line += ';'
             except (KeyboardInterrupt, EOFError):
                 print('\nbye!')
                 break
             try:
-                if line=='exit':
+                if line == 'exit':
                     break
                 if line.startswith('.'):
                     interpret_meta(line)
@@ -265,7 +268,7 @@ if __name__ == "__main__":
                 else:
                     dic = interpret(line)
                     result = execute_dic(dic)
-                    if isinstance(result,Table):
+                    if isinstance(result, Table):
                         result.show()
             except Exception:
                 print(traceback.format_exc())

--- a/mdb.py
+++ b/mdb.py
@@ -160,7 +160,9 @@ def interpret(query):
                      'delete from': ['delete from', 'where'],
                      'update table': ['update table', 'set', 'where'],
                      'create index': ['create index', 'on', 'using'],
-                     'drop index': ['drop index']
+                     'drop index': ['drop index'],
+                     'create view': ['create view','on'],
+                     'drop view': ['drop view']
                      }
 
     if query[-1]!=';':

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -417,7 +417,7 @@ class Database:
         right_table = right_table if isinstance(right_table, Table) else self.tables[right_table]
 
         def spinner (t1,t2):
-           itsright = t1 # this is right table
+            itsright = t1 # this is right table
             right_table = t2 # left  table
             left_table = wasRight
 
@@ -459,17 +459,87 @@ class Database:
                 except:
                     raise Exception(
                         f'Column "{column_name_right}" dont exist in right table. Valid columns: {table_right.column_names}.')
+
+
         #else:
             #raise NotImplementedError
 
-        if save_as is not None:
-            res._name = save_as
-            self.table_from_object(res)
-        else:
-            if return_object:
-                return res
+        #if save_as is not None:
+            #res._name = save_as
+           # self.table_from_object(res)
+       # else:
+            #if return_object:
+                #return res
+            #else:
+                #res.show()
+
+
+
+
+            left_names = [f'{left_table._name}.{colname}' if table_right._name != '' else colname for colname in left_table.column_names]
+            right_names = [f'{table_right._name}.{colname}' if table_right._name != '' else colname for colname in table_right.column_names]
+
+            join_table_name = ''
+            #we need to make take action if we have 'spined' or not
+            if(spin==true):
+                join_table_colnames =right_names+left_names
+                join_table_coltypes=right_table.column_types + left_table.column_types
+
+
             else:
-                res.show()
+                join_table_colnames = left_names + right_names
+                join_table_coltypes=left_table.column_types+right_table.column_types
+
+            join_table = Table(name=join_table_name, column_names=join_table_colnames,
+                                   column_types=join_table_coltypes)
+
+            #now we need the index-nested-join to be in a loop so we can make the table appear(if the spin==1)
+
+            if(spin==0):
+                for row_left in left_table.data:
+                    left_value = row_left[column_index_left]
+                    #finding position of operator starting at the left value
+                    position=index.find(operator,left_value)
+                    under
+                    for i in range(0,len(position)):
+                        if position[i]=="_":
+                            under+=1
+                    y=0
+                    while(y<under):
+                        join_table._insert(row_left + right_table.data[_])
+                else:
+                    for row_left in left_table.data:
+                        left_value = row_left[column_index_left]
+                    # finding position of operator starting at the left value
+                        position = index.find(operator, left_value)
+                        under
+                        for i in range(0, len(position)):
+                            if position[i] == "_":
+                                under += 1
+                        y = 0
+                        while (y < under):
+                            join_table._insert(right_table.data[_]+row_left)
+
+                res=join_table
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     def lock_table(self, table_name, mode='x'):
         '''

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -516,6 +516,35 @@ class Database:
         print('journal:', out)
         #return out
 
+    global views
+    views=[]
+
+    def create_view(self, table_name):
+        views+=table_name
+
+
+    def drop_view(self,table_name):
+
+        #checking if the given table is a view
+        if table_name in views:
+            self.load_database()
+            self.lock_table(table_name)
+
+            self.tables.pop(table_name)
+            if os.path.isfile(f'{self.savedir}/{table_name}.pkl'):
+                os.remove(f'{self.savedir}/{table_name}.pkl')
+            else:
+                warnings.warn(f'"{self.savedir}/{table_name}.pkl" not found.')
+            self.delete_from('meta_locks', f'table_name={table_name}')
+            self.delete_from('meta_length', f'table_name={table_name}')
+            self.delete_from('meta_insert_stack', f'table_name={table_name}')
+
+            self.save_database()
+        else:
+            print("the table name that you have entered is not a view!")
+
+
+
 
     #### META ####
 
@@ -672,3 +701,4 @@ class Database:
         index = pickle.load(f)
         f.close()
         return index
+

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import pickle
 from table import Table
 from time import sleep, localtime, strftime
-import os,sys
+from os import sys
 from btree import Btree
 import shutil
 from misc import split_condition
@@ -414,13 +414,53 @@ class Database:
             return
 
         left_table = left_table if isinstance(left_table, Table) else self.tables[left_table] 
-        right_table = right_table if isinstance(right_table, Table) else self.tables[right_table] 
+        right_table = right_table if isinstance(right_table, Table) else self.tables[right_table]
+
+        def spinner (t1,t2):
+           itsright = t1 # this is right table
+            right_table = t2 # left  table
+            left_table = wasRight
+
 
 
         if mode=='inner':
             res = left_table._inner_join(right_table, condition)
-        else:
-            raise NotImplementedError
+        elif mode   == 'inlj':
+            if (right_table.pk and left_table) is None:
+                res = left_table._inner_join(right_table, condition)
+            else:
+                # we need left table to be right and right table to be left
+                spin = false
+                if right_table.pk == None:
+                    spinner(right_table, left_table)
+                    spin = true
+                else :
+                    spin = false
+                    if right_table.pk == None:
+                        spinner(right_table, left_table)
+                        spin = true
+
+                    index = Btree()
+                    x = 0
+                    adder = enumerate(right_table.column_by_name(right_table.pk))
+                    # we insert very record of the primary into the btree as well as its index
+                    while (x < adder): chosen_index.insert(key.idx)
+
+                column_name_left, operator, column_name_right = self._parse_condition(condition, join=True)
+                # columns find try
+                try:
+                    column_index_left = self.column_names.index(column_name_left)
+                except:
+                    raise Exception(
+                        f'Column "{column_name_left}" dont exist in left table. Valid columns: {self.column_names}.')
+
+                try:
+                    column_index_right = table_right.column_names.index(column_name_right)
+                except:
+                    raise Exception(
+                        f'Column "{column_name_right}" dont exist in right table. Valid columns: {table_right.column_names}.')
+        #else:
+            #raise NotImplementedError
 
         if save_as is not None:
             res._name = save_as

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -512,16 +512,21 @@ class Database:
             out = tabulate({"Command": cache_list.split('\n')}, headers=["Command"])
         else:
             cache_list = '\n'.join([str(readline.get_history_item(i + 1)) for i in range(readline.get_current_history_length())])
-            out = tabulate({"Command": cache_list.split('\n')}, headers=["Index","Command"], showindex="always")
+            out = tabulate({"Command": cache_list.split('\n')}, headers=["Index", "Command"], showindex="always")
         print('journal:', out)
         #return out
 
     global views
     views=[]
+    #instead of list we can create a view table
 
     def create_view(self, table_name):
-        views+=table_name
+        views += table_name
+        self.view() is True
+        return table_name
 
+    def view(self):
+        return False
 
     def drop_view(self,table_name):
 
@@ -701,4 +706,3 @@ class Database:
         index = pickle.load(f)
         f.close()
         return index
-

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -3,7 +3,7 @@ from tabulate import tabulate
 import pickle
 import os
 from misc import get_op, split_condition
-
+from database import Database
 
 class Table:
     '''
@@ -207,7 +207,7 @@ class Table:
                 'column[<,<=,==,>=,>]value' or
                 'value[<,<=,==,>=,>]column'.
                 
-                Operatores supported: (<,<=,==,>=,>)
+                Operators supported: (<,<=,==,>=,>)
             order_by: string. A column name that signals that the resulting table should be ordered based on it (no order if None).
             desc: boolean. If True, order_by will return results in descending order (False by default).
             top_k: int. An integer that defines the number of rows that will be returned (all rows if None).
@@ -236,15 +236,18 @@ class Table:
         # we need to set the new column names/types and no of columns, since we might
         # only return some columns
         dict['column_names'] = [self.column_names[i] for i in return_cols]
-        dict['column_types']   = [self.column_types[i] for i in return_cols]
+        dict['column_types'] = [self.column_types[i] for i in return_cols]
 
         s_table = Table(load=dict) 
         if order_by:
             s_table.order_by(order_by, desc)
 
-        s_table.data = s_table.data[:int(top_k)] if isinstance(top_k,str) else s_table.data
+        s_table.data = s_table.data[:int(top_k)] if isinstance(top_k, str) else s_table.data
 
-        return s_table
+        if Database.view is True:
+            Database.create_table(self, Database.create_view(), dict['column_names'], dict['column_types'], None, None)
+        else:
+            return s_table
 
 
     def _select_where_with_btree(self, return_columns, bt, condition, order_by=None, desc=True, top_k=None):
@@ -289,7 +292,7 @@ class Table:
         if order_by:
             s_table.order_by(order_by, desc)
 
-        s_table.data = s_table.data[:int(top_k)] if isinstance(top_k,str) else s_table.data
+        s_table.data = s_table.data[:int(top_k)] if isinstance(top_k, str) else s_table.data
 
         return s_table
 

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -3,7 +3,7 @@ from tabulate import tabulate
 import pickle
 import os
 from misc import get_op, split_condition
-from database import Database
+##from database import Database
 
 class Table:
     '''

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -422,3 +422,4 @@ class Table:
         f.close()
 
         self.__dict__.update(tmp_dict)
+


### PR DESCRIPTION
Create temp view : 
We made two functions create_view (self, table_name)  and and drop_view (self, table_name) .
create_view takes an instance of database class that can me any table from original database or a table that has been made from a query and this table is given a name that is equal to table_name  also these instances are saved to views =[] list .
![Screenshot 2022-02-13 165426](https://user-images.githubusercontent.com/56501711/153758917-f4aaf332-a74e-431c-85b9-79ad421b25fd.jpg)
drop view  if we want to delete a view  we can call the drop_view(self, table_name) this takes the name of view a search for the views  if the instance drop_view starts the procession of deleting the table with the name given.


Join processing : 
We have two tables and we want to join them but inlj processing requires and index for this procession. To this we need to find
the table with the index if it is the right table we can continue but if not we must change the table right table should be left and left should be right so we spin the we spin function and then we continue with join processing
![Screenshot 2022-02-13 170406](https://user-images.githubusercontent.com/56501711/153759370-f6734db5-2801-400b-9e6e-7e7fe09a9abf.jpg)

