### PR TITLE
Team: Nedo. Issues #79 and #83

### DIFF
--- a/mdb.py
+++ b/mdb.py
@@ -10,12 +10,12 @@ sys.path.append('miniDB')
 from database import Database
 # art font is "big"
 art = '''
-             _         _  _____   ____  
-            (_)       (_)|  __ \ |  _ \     
+             _         _  _____   ____
+            (_)       (_)|  __ \ |  _ \
   _ __ ___   _  _ __   _ | |  | || |_) |
- | '_ ` _ \ | || '_ \ | || |  | ||  _ < 
+ | '_ ` _ \ | || '_ \ | || |  | ||  _ <
  | | | | | || || | | || || |__| || |_) |
- |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2                               
+ |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2
 '''
 
 
@@ -82,16 +82,9 @@ def create_query_plan(query, keywords, action):
         arglist = [val.strip().split(' ') for val in arg_nopk.split(',')]
         dic['column_names'] = ','.join([val[0] for val in arglist])
         dic['column_types'] = ','.join([val[1] for val in arglist])
-        #added 2 more args for not null and unique
-        dic['column_extras'] = ','.join([" ".join(val[2:]) if len(val) > 2 else 'None' for val in arglist])
-        #print(arglist)
         if 'primary key' in args:
-            arglist = args[1:-1].strip().split(' ')
-
-            # check if theres also a pk in the arguments
-            for i in arglist[:arglist.index('primary')]:
-                if i in dic['column_names']:
-                    dic['primary key'] = i
+            arglist = args[1:-1].split(' ')
+            dic['primary key'] = arglist[arglist.index('primary')-2]
         else:
             dic['primary key'] = None
 

--- a/mdb.py
+++ b/mdb.py
@@ -10,12 +10,12 @@ sys.path.append('miniDB')
 from database import Database
 # art font is "big"
 art = '''
-             _         _  _____   ____
-            (_)       (_)|  __ \ |  _ \
+             _         _  _____   ____  
+            (_)       (_)|  __ \ |  _ \     
   _ __ ___   _  _ __   _ | |  | || |_) |
- | '_ ` _ \ | || '_ \ | || |  | ||  _ <
+ | '_ ` _ \ | || '_ \ | || |  | ||  _ < 
  | | | | | || || | | || || |__| || |_) |
- |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2
+ |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2                               
 '''
 
 
@@ -82,9 +82,16 @@ def create_query_plan(query, keywords, action):
         arglist = [val.strip().split(' ') for val in arg_nopk.split(',')]
         dic['column_names'] = ','.join([val[0] for val in arglist])
         dic['column_types'] = ','.join([val[1] for val in arglist])
+        #added 2 more args for not null and unique
+        dic['column_extras'] = ','.join([" ".join(val[2:]) if len(val) > 2 else 'None' for val in arglist])
+        #print(arglist)
         if 'primary key' in args:
-            arglist = args[1:-1].split(' ')
-            dic['primary key'] = arglist[arglist.index('primary')-2]
+            arglist = args[1:-1].strip().split(' ')
+
+            # check if theres also a pk in the arguments
+            for i in arglist[:arglist.index('primary')]:
+                if i in dic['column_names']:
+                    dic['primary key'] = i
         else:
             dic['primary key'] = None
 

--- a/mdb.py
+++ b/mdb.py
@@ -10,13 +10,13 @@ sys.path.append('miniDB')
 from database import Database
 # art font is "big"
 art = '''
-             _         _  _____   ____  
-            (_)       (_)|  __ \ |  _ \     
+             _         _  _____   ____
+            (_)       (_)|  __ \ |  _ \
   _ __ ___   _  _ __   _ | |  | || |_) |
- | '_ ` _ \ | || '_ \ | || |  | ||  _ < 
+ | '_ ` _ \ | || '_ \ | || |  | ||  _ <
  | | | | | || || | | || || |__| || |_) |
- |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2                               
-'''   
+ |_| |_| |_||_||_| |_||_||_____/ |____/   2021 - v3.2
+'''
 
 
 def search_between(s, first, last):
@@ -64,14 +64,14 @@ def create_query_plan(query, keywords, action):
 
     if action=='select':
         dic = evaluate_from_clause(dic)
-        
+
         if dic['order by'] is not None:
             if 'desc' in dic['order by']:
                 dic['desc'] = True
             else:
                 dic['desc'] = False
             dic['order by'] = dic['order by'].removesuffix(' asc').removesuffix(' desc')
-            
+
         else:
             dic['desc'] = None
 
@@ -87,8 +87,8 @@ def create_query_plan(query, keywords, action):
             dic['primary key'] = arglist[arglist.index('primary')-2]
         else:
             dic['primary key'] = None
-    
-    if action=='import': 
+
+    if action=='import':
         dic = {'import table' if key=='import' else key: val for key, val in dic.items()}
 
     if action=='insert into':
@@ -103,7 +103,8 @@ def evaluate_from_clause(dic):
     '''
     Evaluate the part of the query (argument or subquery) that is supplied as the 'from' argument
     '''
-    join_types = ['inner', 'left', 'right', 'full','inlj']
+    #join_types = ['inner', 'left', 'right', 'full','inlj','smj']
+    join_types = ['inner', 'left', 'right', 'full']
     from_split = dic['from'].split(' ')
     if from_split[0] == '(' and from_split[-1] == ')':
         subquery = ' '.join(from_split[1:-1])
@@ -131,7 +132,7 @@ def evaluate_from_clause(dic):
             join_dic['right'] = interpret(join_dic['right'][1:-1].strip())
 
         dic['from'] = join_dic
-        
+
     return dic
 
 def interpret(query):
@@ -156,7 +157,7 @@ def interpret(query):
 
     if query[-1]!=';':
         query+=';'
-    
+
     query = query.replace("(", " ( ").replace(")", " ) ").replace(";", " ;").strip()
 
     for kw in kw_per_action.keys():
@@ -172,7 +173,7 @@ def execute_dic(dic):
     for key in dic.keys():
         if isinstance(dic[key],dict):
             dic[key] = execute_dic(dic[key])
-    
+
     action = list(dic.keys())[0].replace(' ','_')
     return getattr(db, action)(*dic.values())
 
@@ -193,7 +194,7 @@ def interpret_meta(command):
 
     def list_databases(db_name):
         [print(fold.removesuffix('_db')) for fold in os.listdir('dbdata')]
-    
+
     def list_tables(db_name):
         [print(pklf.removesuffix('.pkl')) for pklf in os.listdir(f'dbdata/{db_name}_db') if pklf.endswith('.pkl')\
             and not pklf.startswith('meta')]
@@ -201,7 +202,7 @@ def interpret_meta(command):
     def change_db(db_name):
         global db
         db = Database(db_name, load=True)
-    
+
     def remove_db(db_name):
         shutil.rmtree(f'dbdata/{db_name}_db')
 

--- a/mdb.py
+++ b/mdb.py
@@ -96,21 +96,21 @@ def create_query_plan(query, keywords, action):
             dic['values'] = dic['values'][1:-1]
         else:
             raise ValueError('Your parens are not right m8')
-        
+
     return dic
 
 def evaluate_from_clause(dic):
     '''
     Evaluate the part of the query (argument or subquery) that is supplied as the 'from' argument
     '''
-    join_types = ['inner', 'left', 'right', 'full']
+    join_types = ['inner', 'left', 'right', 'full','inlj']
     from_split = dic['from'].split(' ')
     if from_split[0] == '(' and from_split[-1] == ')':
         subquery = ' '.join(from_split[1:-1])
         dic['from'] = interpret(subquery)
 
-    join_idx = [i for i,word in enumerate(from_split) if word=='join' and not in_paren(from_split,i)]
-    on_idx = [i for i,word in enumerate(from_split) if word=='on' and not in_paren(from_split,i)]
+    join_idx = [i for i, word in enumerate(from_split) if word=='join' and not in_paren(from_split,i)]
+    on_idx = [i for i, word in enumerate(from_split) if word=='on' and not in_paren(from_split,i)]
     if join_idx:
         join_idx = join_idx[0]
         on_idx = on_idx[0]
@@ -138,6 +138,7 @@ def interpret(query):
     '''
     Interpret the query.
     '''
+
     kw_per_action = {'create table': ['create table'],
                      'drop table': ['drop table'],
                      'cast': ['cast', 'from', 'to'],

--- a/miniDB/btree.py
+++ b/miniDB/btree.py
@@ -6,7 +6,7 @@ class Node:
     '''
     Node abstraction. Represents a single bucket
     '''
-    def __init__(self, b, values=[], ptrs=[],\
+    def __init__(self, b, values=[], ptrs=[],
                  left_sibling=None, right_sibling=None, parent=None, is_leaf=False):
         self.b = b # branching factor
         self.values = values # Values (the data from the pk column)

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -46,11 +46,11 @@ class Database:
         except:
             pass
 
-        # create all the meta tables
-        self.create_table('meta_length', 'table_name,no_of_rows', 'str,int')
-        self.create_table('meta_locks', 'table_name,locked', 'str,bool')
-        self.create_table('meta_insert_stack', 'table_name,indexes', 'str,list')
-        self.create_table('meta_indexes', 'table_name,index_name', 'str,str')
+        # create all the meta tables with added arguments
+        self.create_table('meta_length', 'table_name,no_of_rows', 'str,int', '')
+        self.create_table('meta_locks', 'table_name,pid,mode', 'str,int,str', '')
+        self.create_table('meta_insert_stack', 'table_name,indexes', 'str,list', '')
+        self.create_table('meta_indexes', 'table_name,index_name', 'str,str', '')
         self.save_database()
 
     def save_database(self):
@@ -97,8 +97,7 @@ class Database:
         self._update_meta_locks()
         self._update_meta_insert_stack()
 
-
-    def create_table(self, name, column_names, column_types, primary_key=None, load=None):
+    def create_table(self, name, column_names, column_types, column_extras, primary_key=None, load=None):
         '''
         This method create a new table. This table is saved and can be accessed via db_object.tables['table_name'] or db_object.table_name
 
@@ -110,7 +109,8 @@ class Database:
             load: boolean. Defines table object parameters as the name of the table and the column names.
         '''
         # print('here -> ', column_names.split(','))
-        self.tables.update({name: Table(name=name, column_names=column_names.split(','), column_types=column_types.split(','), primary_key=primary_key, load=load)})
+        #the new table has more arguments
+        self.tables.update({name: Table(name=name, column_names=column_names.split(','), column_types=column_types.split(','), column_extras=column_extras.split(','), primary_key=primary_key, load=load)})
         # self._name = Table(name=name, column_names=column_names, column_types=column_types, load=load)
         # check that new dynamic var doesnt exist already
         # self.no_of_tables += 1
@@ -258,6 +258,7 @@ class Database:
         try:
             self.tables[table_name]._insert(row, insert_stack)
         except Exception as e:
+            print(e)
             logging.info(e)
             logging.info('ABORTED')
         # sleep(2)

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -10,7 +10,7 @@ import logging
 import warnings
 import readline
 from tabulate import tabulate
-
+import numpy as np
 
 # sys.setrecursionlimit(100)
 
@@ -421,6 +421,10 @@ class Database:
 
         if mode=='inner':
             res = left_table._inner_join(right_table, condition)
+        elif mode== 'inlj':
+            res = left_table._inl_join(right_table, condition)
+        elif mode == 'smj':
+            pass
         else:
             raise NotImplementedError
 

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -48,7 +48,7 @@ class Database:
 
         # create all the meta tables with added arguments
         self.create_table('meta_length', 'table_name,no_of_rows', 'str,int', '')
-        self.create_table('meta_locks', 'table_name,pid,mode', 'str,int,str', '')
+        self.create_table('meta_locks', 'table_name,locked', 'str,int,bool', '')
         self.create_table('meta_insert_stack', 'table_name,indexes', 'str,list', '')
         self.create_table('meta_indexes', 'table_name,index_name', 'str,str', '')
         self.save_database()
@@ -258,7 +258,6 @@ class Database:
         try:
             self.tables[table_name]._insert(row, insert_stack)
         except Exception as e:
-            print(e)
             logging.info(e)
             logging.info('ABORTED')
         # sleep(2)


### PR DESCRIPTION
### NOT NULL, UNIQUE constraints (+ Btree functionality) - 30/50 https://github.com/DataStories-UniPi/miniDB/issues/79

Υλοποιήθηκε η υποστήριξη **not null** και η υποστήριξη **unique** για την εντολή **create table**. Η αναζήτηση σε unique columns γίνεται με την βοήθεια του ευρετηρίου **Btree.** 
Πιο συγκεκριμένα:
Δημιουργία του κλειδιού column_extras στο dictionary της μεθόδου create_query_plan στο αρχείο **mdb.py.** Το κλειδί column_extras παίρνει ως τιμή not null ή unique.
Ενημέρωση της χρησιμοποίησης του column_extras ως παράμετρο από την κλάση **Table** .
Ενημέρωση της μεθόδου **show** του **Table** ώστε μαζί με τα ονόματα των columns να εμφανίζει τα οποιαδήποτε constraints(PK,NN,UN). 
Ενημέρωση της μεθόδου _parse_condition ώστε να δέχεται το 'null' σαν τίμη για να την ελέγξει όταν μπει σαν όρισμα στο insert για να μπορέσει έπειτα να ελεγθεί ως condition.
Ενημέρωση της μεθόδου _insert ώστε να γίνονται οι κατάλληλοι έλεγχοι σε περίπτωση που εισαχθεί μία τιμή σε not null ή unique στήλη. Στην περίπτωση της εισαγωγής τιμής στη unique στήλη, δημιουργείται ένα btree με όλα τα δεδομένα του πίνακα. Στην περίπτωση του not null ελέγχεται η τιμή του αντίστοιχου πεδίου,και αν αυτή είναι ίση με null και ταυτόχρονα η στήλη έχει τον not null περιορισμό, απορρίπτεται εμφανίζοντας σχετικό μήνυμα λάθους.
Είναι απαραίτητηνη χρήση του **print(column_extras)** για να δοθεί αρχική τιμή και τρέξει αποτελεσματικά το πρόγραμμα.
Στην δημιουργία των **meta tables** ορίζεται η προσθήκη μίας ακόμα παραμέτρου ,αυτή των column_extras ώστε να αποθηκεύονται σωστά οι πίνακες μας.
Στην περίπτωση δημιουργίας προσωρινού πίνακα απο μία φυσική σύνδεση,είναι απαραίτητο ο πίνακας που θα δημιουργηθεί να πληρεί τις προυποθέσεις των ορισμάτων της μεθόδου create_table. 
**Παραδείγματα εκτέλεσης**:

 
![nedo1](https://user-images.githubusercontent.com/61283674/153758830-d1173db4-7d29-476a-ab51-fcd3a6ed261f.png)

###  Join processing - 40/50 https://github.com/DataStories-UniPi/miniDB/issues/83
Υλοποιήθηκαν οι αλγόρυθμοι των ενώσεων**Index nested loop join** και **Sort merge join**.
Στο αρχείο database.py όταν ο parser αναγνωρίζει το keyword join, ελέγχει αν τα εμπλακόμενα tables έχουν κάποιες ιδιότητες(PK,ή αν μπορεί να δημιουργηθεί index(btree),και εφόσον η συνθήκη είναι πάνω στο ΡΚ ώστε να αντιμεταθέτονται εύκολα τα tables) και αν πληρούν τις προυποθέσεις για να τρέξει ο κάθε αλγόριθμος τύπου join.Εφόσον ικανοποιούνται οι προυποθέσεις,μεταφέρονται καταλλήλως τα ορίσματα είτε στην inner_join είτε στις 2 νέες μεθόδους που δημιουργήσαμε (_inlj_join,_smj_join) αφού πρώτα ελεγχθούν οι θέσεις των pk. 
Ορίσαμε την μέθοδο index nested loop join, η οποία φτιάχνει και χρησιμοποιεί ευρετήριο btree στο δεξιό πίνακα της ένωσης( γι αυτό και ελέγχουμε την θέση από την οποία την καλούμε από το  database). Διαθέτει τα ίδια ορίσματα με την  _inner_join(γι αυτό και μπορεί να καλεστεί έναντι αυτής), δημιουργεί έναν κενό πίνακα(ενημερωμένο με το νέο όρισμα του προηγούμενου issue) που αποτελέιται απο τις στήλες των δύο πινάκων που θα γίνει η ένωση και οποιός θα γεμίσει με δεδομένα μετά την εκτέλεση του γνωστού αλγορύθμου inlj.
Ομοιίως, ορίσαμε την smj  η οποία έχει τα ίδια ορίσματα με τις προηγούμενες δύο και ταξινομεί τους πίνακες με βάση την στήλη σύνδεσης(όπου έχουμε επιλέξει να είναι το ΡΚ).Τέλος ο γνωστός αλγόρυθμος smj είναι αυτός που θα γεμίσει με δεδομένα τον κενό πίνακα που θα αποτελείται απο τις στήλες των δύο πινάκων.
**Παραδείγματα εκτέλεσης**:
select * from student inner join advisor on id=s_id
![273827177_274231144818754_6962522092333402025_n](https://user-images.githubusercontent.com/61283674/153762441-9fe0f5bb-410b-4f5d-b63b-7a16565689dc.png)
select * from instructor join department on dept_name=dept_name
![273857621_1048927339022000_282413051382740014_n](https://user-images.githubusercontent.com/61283674/153762578-f183762c-e108-4a9b-a2b4-a5987e9d69f1.png)

Μέλη ομάδας:

- Ιωάννης-Ιάσων Μποϊδάνης π19217 @JasonSDMN2001
- Μιχαήλ Βασιλακάκης π19026 @michalis-vslk