### PR TITLE
Team: Sapites. Issues: #80 and #84

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./miniDB"
+    ]
+}

--- a/mdb.py
+++ b/mdb.py
@@ -77,6 +77,13 @@ def create_query_plan(query, keywords, action):
         else:
             dic['desc'] = None
 
+    if action == 'create trigger':
+        args = dic['create trigger'].split(" ", 1)[-1]
+        dic['create trigger'] = dic['create trigger'].removesuffix(args).strip()
+        arglist = args.split(" ")
+        dic['condition'] = arglist[0]
+        dic['action'] = arglist[1]
+        dic['on'] = arglist[3]
 
     if action=='create table':
         args = dic['create table'][dic['create table'].index('('):dic['create table'].index(')')+1]
@@ -107,7 +114,6 @@ def create_query_plan(query, keywords, action):
             dic['force'] = False
 
     return dic
-
 
 
 def evaluate_from_clause(dic):
@@ -164,7 +170,7 @@ def interpret(query):
                      'drop index' : ['drop index'],
                      'create view' : ['create view', 'on'],
                      'drop view' : ['drop view'],
-                     'create trigger' : ['create trigger', 'condition', 'on', 'action'],
+                     'create trigger' : ['create trigger'],
                      'drop trigger' : ['drop trigger']
                      }
 

--- a/mdb.py
+++ b/mdb.py
@@ -77,10 +77,7 @@ def create_query_plan(query, keywords, action):
         else:
             dic['desc'] = None
 
-    # Needs to be implemented.
-    if action == 'create trigger':
-            dic = evaluate_trigger(dic)
-            return dic
+
 
     if action=='create table':
         args = dic['create table'][dic['create table'].index('('):dic['create table'].index(')')+1]
@@ -115,20 +112,20 @@ def create_query_plan(query, keywords, action):
 # Needs to be implemented
 
 def evaluate_trigger(dic):
-'''
-Evaluate the part of the query that is supplied as the ('before' or 'after' or 'instead') arguement.
-'''
-#x_types = ['insert on', 'delete on', 'update on']
-if 'before' in dic.values():
-before_split = dic['before']
-dic['before'] = interpret(before_split)
-elif 'after' in dic.values():
-after_split = dic['after']
-dic['after'] = interpret(after_split)
-elif 'instead' in dic.values():
-instead_split = dic['instead']
-dic['instead'] = interpret(instead_split)
-return dic
+    '''
+    Evaluate the part of the query that is supplied as the ('before' or 'after' or 'instead') arguement.
+    '''
+    #x_types = ['insert on', 'delete on', 'update on']
+    if 'before' in dic.values():
+        before_split = dic['before']
+        dic['before'] = interpret(before_split)
+    elif 'after' in dic.values():
+        after_split = dic['after']
+        dic['after'] = interpret(after_split)
+    elif 'instead' in dic.values():
+        instead_split = dic['instead']
+        dic['instead'] = interpret(instead_split)
+    return dic
 
 
 
@@ -183,7 +180,9 @@ def interpret(query):
                      'delete from': ['delete from', 'where'],
                      'update table': ['update table', 'set', 'where'],
                      'create index': ['create index', 'on', 'using'],
-                     'drop index': ['drop index'],
+                     'drop index' : ['drop index'],
+                     'create view' : ['create view', 'on'],
+                     'drop view' : ['drop view'],
                      'create trigger' : ['create trigger', 'before', 'after', 'instead', 'insert on', 'delete on', 'update on', 'execute procedure']
                      }
 

--- a/mdb.py
+++ b/mdb.py
@@ -78,7 +78,6 @@ def create_query_plan(query, keywords, action):
             dic['desc'] = None
 
 
-
     if action=='create table':
         args = dic['create table'][dic['create table'].index('('):dic['create table'].index(')')+1]
         dic['create table'] = dic['create table'].removesuffix(args).strip()
@@ -107,24 +106,6 @@ def create_query_plan(query, keywords, action):
         else:
             dic['force'] = False
 
-    return dic
-
-# Needs to be implemented
-
-def evaluate_trigger(dic):
-    '''
-    Evaluate the part of the query that is supplied as the ('before' or 'after' or 'instead') arguement.
-    '''
-    #x_types = ['insert on', 'delete on', 'update on']
-    if 'before' in dic.values():
-        before_split = dic['before']
-        dic['before'] = interpret(before_split)
-    elif 'after' in dic.values():
-        after_split = dic['after']
-        dic['after'] = interpret(after_split)
-    elif 'instead' in dic.values():
-        instead_split = dic['instead']
-        dic['instead'] = interpret(instead_split)
     return dic
 
 
@@ -183,7 +164,8 @@ def interpret(query):
                      'drop index' : ['drop index'],
                      'create view' : ['create view', 'on'],
                      'drop view' : ['drop view'],
-                     'create trigger' : ['create trigger', 'before', 'after', 'instead', 'insert on', 'delete on', 'update on', 'execute procedure']
+                     'create trigger' : ['create trigger', 'condition', 'on', 'action'],
+                     'drop trigger' : ['drop trigger']
                      }
 
     if query[-1]!=';':

--- a/mdb.py
+++ b/mdb.py
@@ -77,6 +77,11 @@ def create_query_plan(query, keywords, action):
         else:
             dic['desc'] = None
 
+    # Needs to be implemented.
+    '''
+    if action == 'create trigger':
+    '''
+    
     if action=='create table':
         args = dic['create table'][dic['create table'].index('('):dic['create table'].index(')')+1]
         dic['create table'] = dic['create table'].removesuffix(args).strip()
@@ -107,7 +112,25 @@ def create_query_plan(query, keywords, action):
 
     return dic
 
+# Needs to be implemented
 
+def evaluate_trigger(dic):
+    '''
+    Evaluate the part of the query that is supplied as the ('before' or 'after' or 'instead') arguement.
+    '''
+    x_types = ['insert on', 'delete on', 'update on']
+    before_split = dic['before']
+    after_split = dic['after']
+    instead_split = dic['instead']
+
+    if before_split:
+        dic['before'] = interpret(before_split)
+    elif after_split:
+        dic['after'] = interpret(after_split)
+    elif instead_split:
+        dic['instead'] = interpret(instead_split)
+
+    
 
 def evaluate_from_clause(dic):
     '''
@@ -160,7 +183,8 @@ def interpret(query):
                      'delete from': ['delete from', 'where'],
                      'update table': ['update table', 'set', 'where'],
                      'create index': ['create index', 'on', 'using'],
-                     'drop index': ['drop index']
+                     'drop index': ['drop index'],
+                     'create trigger' : ['create trigger', 'before', 'after', 'instead', 'insert on', 'delete on', 'update on', 'execute procedure']
                      }
 
     if query[-1]!=';':

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from msilib import init_database
 import pickle
 from table import Table
 from time import sleep, localtime, strftime
@@ -516,6 +517,25 @@ class Database:
         print('journal:', out)
         #return out
 
+
+    # Needs to be implemented.
+    '''
+    def create_trigger(self, table_name, keyword):
+
+        self.load_database()
+        lock_ownership = self.lock_table(table_name, mode='x')
+
+
+        if keyword == "AFTER"
+
+
+
+        if lock_ownership:
+            self.unlock_table(table_name)
+        self._update()
+        self.save_database()
+    '''
+    
 
     #### META ####
 

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -526,7 +526,7 @@ class Database:
         lock_ownership = self.lock_table(table_name, mode='x')
 
 
-        if keyword == "AFTER"
+        
 
 
 

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -238,7 +238,7 @@ class Database:
         self._update()
         self.save_database()
 
-    def insert_into(self, table_name, row_str):
+    def insert_into(self, table_name, row_str, flag = False):
         '''
         Inserts data to given table.
 
@@ -246,6 +246,8 @@ class Database:
             table_name: string. Name of table (must be part of database).
             row: list. A list of values to be inserted (will be casted to a predifined type automatically).
             lock_load_save: boolean. If False, user needs to load, lock and save the states of the database (CAUTION). Useful for bulk-loading.
+            flag: Boolean. False, when an insert query can't be executed on the 'meta_triggers' table.
+                           True, when an insert query can be executed on the 'meta_triggers' table.
         '''
         row = row_str.strip().split(',')
         self.load_database()
@@ -622,6 +624,7 @@ class Database:
         self.save_database()
         '''
 
+
     def drop_trigger(self, trigger_name):
         '''
         This function deletes a trigger of a specific table of the database from the 'meta_triggers' table.
@@ -632,6 +635,29 @@ class Database:
 
         self.load_database()
         self.delete_from("meta_triggers", "trigger_name=" + trigger_name, True)
+
+
+    def count_trigger(self, table_name, condition, action):
+        '''
+        This function searches the 'meta_triggers' table in order to find out how many 
+        times has a trigger been created with the same action and condition on a table.
+
+        Args:
+            table_name: string. The table for whom the trigger is created.
+            condition: string. It only accepts the values 'BEFORE', 'AFTER', 'INSTEAD'. 
+            action: string. It only accepts the values 'INSERT', 'DELETE', 'UPDATE'.   
+        '''
+        counter = 0
+
+        tables = self.tables["meta_triggers"].column_by_name("table_name")
+        conditions = self.tables["meta_triggers"].column_by_name("condition")
+        actions = self.tables["meta_triggers"].column_by_name("actions")
+
+        for i in range(len(tables)):
+            if tables[i] == table_name and conditions[i] == condition and actions[i] == action:
+                counter += 1
+
+        return counter
 
 
     #### META ####

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -140,6 +140,8 @@ class Table:
                 
                 Operatores supported: (<,<=,=,>=,>)
         '''
+        # the update has not happened yet and table has not been modified.
+        table_modified = False
         # parse the condition
         column_name, operator, value = self._parse_condition(condition)
 
@@ -153,9 +155,13 @@ class Table:
         for row_ind, column_value in enumerate(column):
             if get_op(operator, column_value, value):
                 self.data[row_ind][set_column_idx] = set_value
+                # the update query is completed and the table got modified.
+                table_modified = True
+
+        return table_modified
 
         # self._update()
-                # print(f"Updated {len(indexes_to_del)} rows")
+        # print(f"Updated {len(indexes_to_del)} rows")
 
 
     def _delete_where(self, condition):
@@ -423,10 +429,6 @@ class Table:
 
         self.__dict__.update(tmp_dict)
 
-    # Needs to be implemented.
-    '''
-    def _create_trigger(self, condition):
-    '''
     
         
         

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -422,3 +422,12 @@ class Table:
         f.close()
 
         self.__dict__.update(tmp_dict)
+
+    # Needs to be implemented.
+    '''
+    def _create_trigger(self, condition):
+    '''
+    
+        
+        
+

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -145,7 +145,7 @@ class Table:
         # parse the condition
         column_name, operator, value = self._parse_condition(condition)
 
-        # get the condition and the set column
+        # get the condition and the set column  
         column = self.column_by_name(column_name)
         set_column_idx = self.column_names.index(set_column)
 
@@ -233,6 +233,7 @@ class Table:
             rows = [ind for ind, x in enumerate(column) if get_op(operator, x, value)]
         else:
             rows = [i for i in range(len(self.data))]
+
 
         # top k rows
         # rows = rows[:int(top_k)] if isinstance(top_k,str) else rows


### PR DESCRIPTION
 **CREATE [TEMP] VIEW name ΟΝ (SELECT …); DROP VIEW name - 30/50**  #80  

Πραγματοποιήσαμε δύο διαφορετικές υλοποιήσεις για τη δημιουργία view, καθώς και μία για την διαγραφή τους. Αρχικά, η δημιουργία materialized view οφείλεται στην function **create_view**, ενώ αντίστοιχα του temp view στην **create_tempview**. Επίσης,  η διαγραφή κάποιου view γίνεται λόγω της **drop_view**, ενώ η διαγραφή ενός temporary view πραγματοποιείται με τις functions **drop_view** και **clear_tempviews**. Όλες αυτές οι functions, αφορούν το αρχείο **database.py**. Επιπρόσθετα, δουλέψαμε και στο αρχείο **mdb.py**, μέσα στο οποίο υλοποιήσαμε το interpretation των **create view, create tempview και drop view**. Παράλληλα δημιουργήσαμε και τα αντίστοιχα actions, τα οποία είναι ουσιαστικά αντιγραφή του select, μιας και προσεγγίσαμε το ερώτημα με αυτήν την νοοτροπία.  Τελικά, σε ό,τι αφορά στην εκτέλεση του issue, μπορεί να γίνει δημιουργία view, το οποίο θα παραμείνει saved. Η αντίστοιχη εντολή είναι: `create view view_name select column from table;`. Η δημιουργία temporary view γίνεται με: `create tempview tempview_name select column from table;`. Τέλος, προκειμένου να διαγραφεί κάποιο view, γίνεται με την εντολή: `drop view view_name;`, όμως το temporary view θα διαγραφεί κατά την έξοδο από την εφαρμογή.

**Παραδείγματα εκτέλεσης:**

![create_view1](https://user-images.githubusercontent.com/60470403/153772315-d6ddd64e-bfdc-47a9-9529-ee13e79045f3.png)

Δημιουργία materialized view.


![select_a](https://user-images.githubusercontent.com/60470403/153772358-b1faf75b-f115-4c7d-8243-a2be8bbb3360.png)

Εκτέλεση της εντολής select πάνω στο materialized view έχοντας κάνει έξοδο από την db.


![temp_view1](https://user-images.githubusercontent.com/60470403/153772419-4d095866-9881-4095-bd47-baace1aa130d.png)

Δημιουργία temporary view.


![fail_temp](https://user-images.githubusercontent.com/60470403/153772447-29670ba7-86e9-4d76-a414-c04e82d2bb99.png)

Εκτέλεση της εντολής select πάνω σε temporary view έχοντας κάνει έξοδο από την db.


![drop](https://user-images.githubusercontent.com/60470403/153772494-f6e839d7-a1b6-4fdd-b34c-ebed0a784185.png)

Εκτέλεση της εντολής drop view πάνω σε view.


**CREATE TRIGGER name ON func / DROP TRIGGER name ... - 40/50** #84 

Σε ότι αφορά στο issue #84, έγινε απόπειρα υλοποίησής του χωρίς ιδιαίτερο αποτέλεσμα. 
Το πρόβλημα που συναντήσαμε ήταν στην εισαγωγή του trigger σε εναν πίνακα meta_triggers που δημιουργήσαμε και συγκεκριμένα στο σημείο αυτό: `insert_stack = self._get_insert_stack_for_table(table_name)`. Αναφορικά με το τί καταφέραμε να κάνουμε, υλοποιήσαμε το interpretation των **create trigger** και **drop trigger** στο **mdb.py** αρχείο.
Παράλληλα, δημιουργήσαμε στο **database.py** τις **create_trigger** και **drop_trigger**. Η πρώτη, ελέγχει το περιεχόμενο των παραμέτρων ώστε να διασφαλίζεται ότι το trigger θα έχει οπωσδήποτε όνομα και θα ακολουθείται η γενική δομή: `create trigger trigger_name before|after|instead insert|delete| update on table_name;`. Από την άλλη, το **drop_trigger**, όπως είναι προφανές, χρησιμοποιείται για την διαγραφή ενός trigger και αυτό το καταφέρνει με την διαγραφή του από τον πίνακα **meta_triggers**. Ακόμα, υλοποιήσαμε την function **count_trigger**, η οποία μετρά πόσες φορές έχει δημιουργηθεί ένα trigger για κάποιο συγκεκριμένο  action (INSERT, DELETE, UPDATE) και ένα συγκεκριμένο condition (BEFORE, AFTER). Όταν κάποιο trigger ενεργοποιείται, θέλαμε να καλείται μέσα στην αντίστοιχη function (insert_into, delete_from, update_table) η function do_something, η οποία θα εμφάνιζε το αντίστοιχο μήνυμα.
Τέλος, μέσα στις functions **insert_into**, **delete_from**, **update_table**, θέλαμε να καταφέρουμε να σκάνε όντως τα trigger όταν γίνεται insert, delete, update, ανάλογα με τα condition BEFORE, AFTER. 
