### PR TITLE
Finished #81 and #83

### DIFF
--- a/mdb.py
+++ b/mdb.py
@@ -98,17 +98,23 @@ def create_query_plan(query, keywords, action):
             
             arglist = args[1:-1].split(' ')
 
-            print(f'\narglist: {arglist}\n')
-
-            # foreign key will eventually become a list cause we can have 
-            # more than one foreign key in a table
-            dic['foreign key'] = arglist[arglist.index('foreign')-2]
-
+            dic['foreign key'] = []
             dic['ref'] = []
-            dic['ref'].append(arglist[arglist.index('ref')+1])
-            dic['ref'].append(arglist[arglist.index('ref')+2])
+
+            # find all the columns that will be used for the foreign key
+            # and all referenced data (tables and columns)
+            for i in range(len(arglist)):
+                if arglist[i] == 'foreign':
+                    dic['foreign key'].append(arglist[i-2])
+
+                if arglist[i] == 'ref':
+                    dic['ref'].append(arglist[i+1].replace(',', '')) # need the replace method cause for some reason ',' is passed when included
+                    dic['ref'].append(arglist[i+2].replace(',', ''))
+
 
             print(f'dic[\'foreign key\']: {dic["foreign key"]}')
+
+            print(f'dic[\'ref\']: {dic["ref"]}')
     
     if action=='import': 
         dic = {'import table' if key=='import' else key: val for key, val in dic.items()}

--- a/mdb.py
+++ b/mdb.py
@@ -89,6 +89,26 @@ def create_query_plan(query, keywords, action):
             dic['primary key'] = arglist[arglist.index('primary')-2]
         else:
             dic['primary key'] = None
+        
+        if 'foreign key' in args:
+
+            if not 'ref' in args:
+                print(f'Error: Didn\'t provide a reference table and column for the foreign key.')
+                return
+            
+            arglist = args[1:-1].split(' ')
+
+            print(f'\narglist: {arglist}\n')
+
+            # foreign key will eventually become a list cause we can have 
+            # more than one foreign key in a table
+            dic['foreign key'] = arglist[arglist.index('foreign')-2]
+
+            dic['ref'] = []
+            dic['ref'].append(arglist[arglist.index('ref')+1])
+            dic['ref'].append(arglist[arglist.index('ref')+2])
+
+            print(f'dic[\'foreign key\']: {dic["foreign key"]}')
     
     if action=='import': 
         dic = {'import table' if key=='import' else key: val for key, val in dic.items()}

--- a/mdb.py
+++ b/mdb.py
@@ -92,29 +92,33 @@ def create_query_plan(query, keywords, action):
         
         if 'foreign key' in args:
 
+            # if user didn't reference anything, print error and do nothing
             if not 'ref' in args:
                 print(f'Error: Didn\'t provide a reference table and column for the foreign key.')
                 return
             
             arglist = args[1:-1].split(' ')
 
+            # create a list for both foreign key and ref cause 
+            # there might be more than one foreign key
             dic['foreign key'] = []
             dic['ref'] = []
 
             # find all the columns that will be used for the foreign key
             # and all referenced data (tables and columns)
             for i in range(len(arglist)):
-                if arglist[i] == 'foreign':
-                    dic['foreign key'].append(arglist[i-2])
 
+                # append the foreign key column of the soon to be created table
+                if arglist[i] == 'foreign':
+                    dic['foreign key'].append(arglist[i-2]) # we know that it will always be 2 indexes before the word foreign
+
+                # append the referenced table name and the table column to the list
                 if arglist[i] == 'ref':
+                    # we know that the first value after the word ref is going to be the referenced table
+                    # and after it the referenced column of that table
                     dic['ref'].append(arglist[i+1].replace(',', '')) # need the replace method cause for some reason ',' is passed when included
                     dic['ref'].append(arglist[i+2].replace(',', ''))
 
-
-            print(f'dic[\'foreign key\']: {dic["foreign key"]}')
-
-            print(f'dic[\'ref\']: {dic["ref"]}')
     
     if action=='import': 
         dic = {'import table' if key=='import' else key: val for key, val in dic.items()}

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -424,8 +424,13 @@ class Database:
 
 
         if mode=='inner':
-            print(self.evaluate_join_method(left_table))
-            res = left_table._inner_join(right_table, condition)
+            
+            if self.evaluate_join_method(left_table):
+                # call inlj() here
+                pass
+            else:
+                res = left_table._inner_join(right_table, condition)
+
         else:
             raise NotImplementedError
 

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -472,10 +472,12 @@ class Database:
 
         # check if both tables are sorted
         if not left_table.is_sorted():
-            left_table.e_merge_sort()
+            # left_table.e_merge_sort()
+            pass
 
         if not left_table.is_sorted():
-            right_table.e_merge_sort()
+            # right_table.e_merge_sort()
+            pass
 
         left_table_length = len(left_table.data)
         right_table_length = len(right_table.data)
@@ -537,7 +539,10 @@ class Database:
             #     pass
             # else:
 
-                res = left_table._inner_join(right_table, condition)
+                # added just for testing
+                res = self.smj(left_table, right_table, condition)
+
+                # res = left_table._inner_join(right_table, condition)
 
         else:
             raise NotImplementedError

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -444,7 +444,7 @@ class Database:
 
             return join_table
 
-    def smj(self, left_table, right_table, condition = '=='):
+    def smj(self, left_table, right_table, condition):
         
         # get columns and operator
         column_name_left, operator, column_name_right = left_table._parse_condition(condition, join=True)

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -108,14 +108,27 @@ class Database:
             primary_key: string. The primary key (if it exists).
             load: boolean. Defines table object parameters as the name of the table and the column names.
         '''
-        print(f'\nforeign key: {foreign_key}\n')
+        # print(f'\nforeign key: {foreign_key}\n')
 
-        print(f'\nref[0]: {ref[0]}\n')
+        # print(f'\nref[0]: {ref[0]}\n')
 
-        if not ref[0] in self.tables:
-            print(f'ERROR: Cannot create table {name}\n')
-            print(f'Referenced table {ref[0]} does not exist! \n')
-            return
+        if ref != None:
+
+            if not ref[0] in self.tables:
+                print(f'ERROR: Cannot create table {name}\n')
+                print(f'Referenced table {ref[0]} does not exist! \n')
+                return
+
+            # check if column names are part of a table
+            if not ref[1] in column_names:
+                print(f'ERROR: Column {ref[1]} doesn\'t exist in table {ref[0]}') 
+                return
+
+            # check if given referenced column is the pk of the given referenced table
+            if self.tables.get(ref[0]).pk != ref[1:-1]:
+                print(f'{self.tables.get(ref[0]).pk}')
+                print(f'{ref[1:-1]}')
+            
 
         # print('here -> ', column_names.split(','))
         self.tables.update({name: Table(name=name, column_names=column_names.split(','), column_types=column_types.split(','), primary_key=primary_key, foreign_key=foreign_key, ref=ref, load=load)})

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -467,7 +467,7 @@ class Database:
         # define the new tables name, its column names and types
         join_table_name = ''
         join_table_colnames = left_names+right_names
-        join_table_coltypes = self.column_types+right_table.column_types
+        join_table_coltypes = left_table.column_types+right_table.column_types
         join_table = Table(name=join_table_name, column_names=join_table_colnames, column_types= join_table_coltypes)
 
         # check if both tables are sorted
@@ -496,7 +496,7 @@ class Database:
 
                 join_table._insert(left_table.data[i] + right_table.data[j])
 
-                if(right_table[j - 1][column_index_right] != right_table[j][column_index_right]):
+                if(right_table.data[j - 1][column_index_right] != right_table.data[j][column_index_right]):
                     first_occurrence = j
                 
                 if(j + 1 > right_table_length):

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -394,6 +394,12 @@ class Database:
         self._update()
         self.save_database()
 
+    def evaluate_join_method(self, left_table):
+        if(left_table.pk == None):
+            return False
+        else:
+            return True
+
     def join(self, mode, left_table, right_table, condition, save_as=None, return_object=True):
         '''
         Join two tables that are part of the database where condition is met.
@@ -418,6 +424,7 @@ class Database:
 
 
         if mode=='inner':
+            print(self.evaluate_join_method(left_table))
             res = left_table._inner_join(right_table, condition)
         else:
             raise NotImplementedError
@@ -430,10 +437,6 @@ class Database:
                 return res
             else:
                 res.show()
-
-    def evaluate_join_method(self):
-        pass
-
 
     def lock_table(self, table_name, mode='x'):
         '''

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -400,8 +400,9 @@ class Database:
         else:
             return True
             
-    def inlj(self, left_table, right_table): 
-        if (left_table.pk <> none):
+    def inlj(self, left_table, right_table):
+        
+        if (left_table.pk != none):
             # get columns and operator
             column_name_left, operator, column_name_right = self._parse_condition(condition, join=True)
             # try to find both columns, if you fail raise error
@@ -428,7 +429,7 @@ class Database:
 
             if(self._has_index(left_table)):
                 #inlj algorithm
-
+                pass
 
     def smj(self, left_table, right_table):
         

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -431,6 +431,10 @@ class Database:
             else:
                 res.show()
 
+    def evaluate_join_method():
+        pass
+
+
     def lock_table(self, table_name, mode='x'):
         '''
         Locks the specified table using the exclusive lock (X).

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -634,9 +634,6 @@ class Database:
 
         if mode=='inner':
             
-            print(f'type(left_table): {type(left_table)}')
-            print(f'type(right_table): {type(right_table)}')
-            print(f'type(right_table): {type(condition)}')
             method = self.evaluate_join_method(left_table, right_table, condition)
             if method == 'SMJ':
                 print(f'Using SMJ')

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -447,27 +447,27 @@ class Database:
     def smj(self, left_table, right_table):
         
         # get columns and operator
-        column_name_left, operator, column_name_right = self._parse_condition(condition, join=True)
+        column_name_left, operator, column_name_right = left_table._parse_condition(condition, join=True)
         # try to find both columns, if you fail raise error
         try:
-            column_index_left = self.column_names.index(column_name_left)
+            column_index_left = left_table.column_names.index(column_name_left)
         except:
-            raise Exception(f'Column "{column_name_left}" dont exist in left table. Valid columns: {self.column_names}.')
+            raise Exception(f'Column "{column_name_left}" dont exist in left table. Valid columns: {left_table.column_names}.')
 
         try:
-            column_index_right = table_right.column_names.index(column_name_right)
+            column_index_right = right_table.column_names.index(column_name_right)
         except:
-            raise Exception(f'Column "{column_name_right}" dont exist in right table. Valid columns: {table_right.column_names}.')
+            raise Exception(f'Column "{column_name_right}" dont exist in right table. Valid columns: {right_table.column_names}.')
 
         # get the column names of both tables with the table name in front
         # ex. for left -> name becomes left_table_name_name etc
-        left_names = [f'{self._name}.{colname}' if self._name!='' else colname for colname in self.column_names]
-        right_names = [f'{table_right._name}.{colname}' if table_right._name!='' else colname for colname in table_right.column_names]
+        left_names = [f'{left_table._name}.{colname}' if left_table._name!='' else colname for colname in left_table.column_names]
+        right_names = [f'{right_table._name}.{colname}' if right_table._name!='' else colname for colname in right_table.column_names]
 
         # define the new tables name, its column names and types
         join_table_name = ''
         join_table_colnames = left_names+right_names
-        join_table_coltypes = self.column_types+table_right.column_types
+        join_table_coltypes = self.column_types+right_table.column_types
         join_table = Table(name=join_table_name, column_names=join_table_colnames, column_types= join_table_coltypes)
 
         # check if both tables are sorted
@@ -477,27 +477,25 @@ class Database:
         if not left_table.is_sorted():
             right_table.e_merge_sort()
 
-        res:Table
-
         left_table_length = len(left_table.data)
         right_table_length = len(right_table.data)
 
         i = 0
         j = 0
-        k = 0
+        first_occurrence = 0
 
         while (i < left_table_length and j < right_table_length):
-            if (left_table.data[i][i] < right_table.data[j][j]):
+            if (left_table.data[i][column_index_left] < right_table.data[j][column_index_right]):
                 i += 1
                 
 
-            elif (left_table.data[i][i] > right_table.data[j][j]):
+            elif (left_table.data[i][column_index_left] > right_table.data[j][column_index_right]):
                 j += 1
 
             else:
                 rows = []
-                rows.append(left_table.data[i][i])
-                rows.append(right_table.data[j][j])
+                rows.append(left_table.data[i][column_index_left])
+                rows.append(right_table.data[j][column_index_right])
                 
                 res._insert(rows)
 
@@ -529,9 +527,7 @@ class Database:
 
             #     pass
             # else:
-                data = left_table.data
-                column_name_left, operator, column_name_right = left_table._parse_condition(condition, join=True)
-                print(left_table.column_names.index(column_name_left))
+            
                 res = left_table._inner_join(right_table, condition)
 
         else:

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -440,7 +440,8 @@ class Database:
         if not left_table.is_sorted():
             right_table.e_merge_sort()
 
-        res = []
+        res:Table
+
         left_table_length = len(left_table.data)
         right_table_length = len(right_table.data)
 
@@ -448,6 +449,20 @@ class Database:
         j = 0
         k = 0
 
+        while (i < left_table_length and j < right_table_length):
+            if (left_table.data[i][i] < right_table.data[j][j]):
+                i += 1
+                
+
+            elif (left_table.data[i][i] > right_table.data[j][j]):
+                j += 1
+
+            else:
+                rows = []
+                rows.append(left_table.data[i][i])
+                rows.append(right_table.data[j][j])
+                
+                res._insert(rows)
 
     def join(self, mode, left_table, right_table, condition, save_as=None, return_object=True):
         '''
@@ -475,9 +490,11 @@ class Database:
         if mode=='inner':
             
             if self.evaluate_join_method(left_table, right_table):
-                
+
                 pass
             else:
+                data = left_table.data
+                print(data[0][0])
                 res = left_table._inner_join(right_table, condition)
 
         else:

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -444,7 +444,7 @@ class Database:
 
             return join_table
 
-    def smj(self, left_table, right_table):
+    def smj(self, left_table, right_table, condition = '=='):
         
         # get columns and operator
         column_name_left, operator, column_name_right = left_table._parse_condition(condition, join=True)

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -400,6 +400,25 @@ class Database:
         else:
             return True
 
+
+    def smj(self, left_table, right_table):
+        
+        # check if both tables are sorted
+        if not left_table.is_sorted():
+            left_table.e_merge_sort()
+
+        if not left_table.is_sorted():
+            right_table.e_merge_sort()
+
+        res = []
+        left_table_length = len(left_table.data)
+        right_table_length = len(right_table.data)
+
+        i = 0
+        j = 0
+        k = 0
+
+
     def join(self, mode, left_table, right_table, condition, save_as=None, return_object=True):
         '''
         Join two tables that are part of the database where condition is met.
@@ -426,7 +445,7 @@ class Database:
         if mode=='inner':
             
             if self.evaluate_join_method(left_table, right_table):
-                # call inlj() here
+                
                 pass
             else:
                 res = left_table._inner_join(right_table, condition)

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -493,11 +493,20 @@ class Database:
                 j += 1
 
             else:
-                rows = []
-                rows.append(left_table.data[i][column_index_left])
-                rows.append(right_table.data[j][column_index_right])
+
+                join_table._insert(left_table.data[i] + right_table.data[j])
+
+                if(right_table[j - 1][column_index_right] != right_table[j][column_index_right]):
+                    first_occurrence = j
                 
-                res._insert(rows)
+                if(j + 1 > right_table_length):
+                    i += 1
+                    j = first_occurrence
+                else:
+                    j += 1
+        
+        return join_table
+
 
     def join(self, mode, left_table, right_table, condition, save_as=None, return_object=True):
         '''
@@ -527,7 +536,7 @@ class Database:
 
             #     pass
             # else:
-            
+
                 res = left_table._inner_join(right_table, condition)
 
         else:

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -108,27 +108,35 @@ class Database:
             primary_key: string. The primary key (if it exists).
             load: boolean. Defines table object parameters as the name of the table and the column names.
         '''
-        print(f'\nforeign key: {foreign_key}\n')
 
-        print(f'\nref[0]: {ref[0]}\n')
+        if foreign_key != None and ref != None:
 
-        if ref != None:
+            for i in range(len(ref)):
 
-            if not ref[0] in self.tables:
-                print(f'ERROR: Cannot create table {name}\n')
-                print(f'Referenced table {ref[0]} does not exist! \n')
-                return
+                # check if index of loop is an even number
+                # we need that cause in ref in each "even" index
+                # we have stored the referenced table
+                # and in each "odd" index we have stored
+                # each refernced column of that table
+                if i % 2 == 0:
 
-            # check if column names are part of a table
-            if not ref[1][0:-1] in self.tables.get(ref[0]).column_names:
-                print(f'ERROR: Column {ref[1]} doesn\'t exist in table {ref[0]}') 
-                return
+                    if not ref[i] in self.tables:
+                        print(f'ERROR: Cannot create table {name}\n')
+                        print(f'Referenced table {ref[i]} does not exist! \n')
+                        return
 
-            # check if given referenced column is the pk of the given referenced table
-            if self.tables.get(ref[0]).pk != ref[1][0:-1]:
-                print(f'{self.tables.get(ref[0]).pk}')
-                print(f'{ref[1][0:-1]}')
-            
+                else:
+
+                    # check if column names are part of a table
+                    if not ref[i] in self.tables.get(ref[i-1]).column_names:
+                        print(f'ERROR: Column {ref[i]} doesn\'t exist in table {ref[i-1]}')
+                        return
+
+                    # check if given referenced column is the pk (in the future we should also check if the column is unique)
+                    # of the given referenced table
+                    if self.tables.get(ref[i-1]).pk != ref[i]:
+                        print(f'ERROR: Column {ref[i]} is not a pk of table {ref[i-1]}')
+                        return
 
         # print('here -> ', column_names.split(','))
         self.tables.update({name: Table(name=name, column_names=column_names.split(','), column_types=column_types.split(','), primary_key=primary_key, foreign_key=foreign_key, ref=ref, load=load)})

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -394,8 +394,8 @@ class Database:
         self._update()
         self.save_database()
 
-    def evaluate_join_method(self, left_table):
-        if(left_table.pk == None):
+    def evaluate_join_method(self, left_table, right_table):
+        if(left_table.pk == None and right_table.pk == None):
             return False
         else:
             return True
@@ -425,7 +425,7 @@ class Database:
 
         if mode=='inner':
             
-            if self.evaluate_join_method(left_table):
+            if self.evaluate_join_method(left_table, right_table):
                 # call inlj() here
                 pass
             else:

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -446,6 +446,30 @@ class Database:
 
     def smj(self, left_table, right_table):
         
+        # get columns and operator
+        column_name_left, operator, column_name_right = self._parse_condition(condition, join=True)
+        # try to find both columns, if you fail raise error
+        try:
+            column_index_left = self.column_names.index(column_name_left)
+        except:
+            raise Exception(f'Column "{column_name_left}" dont exist in left table. Valid columns: {self.column_names}.')
+
+        try:
+            column_index_right = table_right.column_names.index(column_name_right)
+        except:
+            raise Exception(f'Column "{column_name_right}" dont exist in right table. Valid columns: {table_right.column_names}.')
+
+        # get the column names of both tables with the table name in front
+        # ex. for left -> name becomes left_table_name_name etc
+        left_names = [f'{self._name}.{colname}' if self._name!='' else colname for colname in self.column_names]
+        right_names = [f'{table_right._name}.{colname}' if table_right._name!='' else colname for colname in table_right.column_names]
+
+        # define the new tables name, its column names and types
+        join_table_name = ''
+        join_table_colnames = left_names+right_names
+        join_table_coltypes = self.column_types+table_right.column_types
+        join_table = Table(name=join_table_name, column_names=join_table_colnames, column_types= join_table_coltypes)
+
         # check if both tables are sorted
         if not left_table.is_sorted():
             left_table.e_merge_sort()
@@ -499,15 +523,15 @@ class Database:
         left_table = left_table if isinstance(left_table, Table) else self.tables[left_table] 
         right_table = right_table if isinstance(right_table, Table) else self.tables[right_table] 
 
-
         if mode=='inner':
             
-            if self.evaluate_join_method(left_table, right_table):
+            # if self.evaluate_join_method(left_table, right_table):
 
-                pass
-            else:
+            #     pass
+            # else:
                 data = left_table.data
-                print(data[0][0])
+                column_name_left, operator, column_name_right = left_table._parse_condition(condition, join=True)
+                print(left_table.column_names.index(column_name_left))
                 res = left_table._inner_join(right_table, condition)
 
         else:

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -14,6 +14,8 @@ class Table:
         - column names (list of strings)
         - column types (list of functions like str/int etc)
         - primary (name of the primary key column)
+        - foreign_key: list. Name of foreign key columns (or foreign key cause there might be only one).
+        - ref: list. Contains name of parent table followed by the primary key column of the parent table.
 
     OR
 
@@ -69,7 +71,7 @@ class Table:
                 self.fk_idx =[] # a list with all the foreign key columns
                 self.ref_table = ref[0] # store the parent table
 
-                #populate that list
+                # populate fk_idx list with every column name
                 for i in range(len(foreign_key)):
 
                     self.fk_idx.append(foreign_key[i])
@@ -393,7 +395,9 @@ class Table:
             # table has a primary key, add PK next to the appropriate column
             headers[self.pk_idx] = headers[self.pk_idx]+' #PK#'
 
+        # if table has foreign keys
         if self.fk_idx != None:
+            # add the #FK# tag next to each column in the list fk_idx
             for i in range(len(self.fk_idx)):
                 headers[i] = headers[i] +' #FK#'
         

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -67,6 +67,7 @@ class Table:
 
             if foreign_key != None and ref != None:
                 self.fk_idx =[] # a list with all the foreign key columns
+                self.ref_table = ref[0] # store the parent table
 
                 #populate that list
                 for i in range(len(foreign_key)):
@@ -75,6 +76,7 @@ class Table:
 
             else:
                 self.fk_idx = None
+                self.ref_table = None
 
             # self._update()
 


### PR DESCRIPTION
Contributors:
Όνομα: Απόστολος Σίδερης
AM: Π19239

Όνομα: Σοφία-Μαρία Νικολιά
ΑΜ: Π19122

Είχαμε να υλοποιήσουμε τα Issues #81 και #83.

* Στο #81 πρέπει να προσθέσουμε την δυνατότητα δημιουργίας `foreign keys` καθώς και τα διάφορα `referential constraints`. 
Ένα παράδειγμα χρήσης και επεξήγηση:

```
create table students(sid int primary key, fname str, lname str, dept_name str);

create table instructor(sid int primary key, fname str, lname str, dept_name str);

insert into students values(1, jason, barb, cs);
insert into students values(2, thanasis, tsiar, cs);
insert into students values(3, john, skou, cs);

insert into instructor values(1, nick, theo, cs);
insert into instructor values(2, mary, roza, bio);

create table income(sid int foreign key ref students sid, money int);

insert into income values(1, 23000);
```
![1_general_select](https://user-images.githubusercontent.com/93468476/153775805-9c346193-4c7f-4438-b993-7206dd4f5f7a.png)



Δημιουργία πίνακα με foreign keys:
```
create table assignment(stu_sid int foreign key ref students sid, stu_fname str, instr_sid int foreign key ref instructor sid, instr_lname str);
```

Η σύνταξη είναι απλή, πρώτα δίνουμε το όνομα της στήλης, μετά την ορίζουμε ως foreign key, μετά δίνουμε τα references `ref` τον `parent` πίνακα καθώς και την στήλη. Επίσης γίνεται και έλεγχος για την εισαγωγή των στοιχείων σε έναν πίνακα με `foreign keys`. Πρέπει να υπάρχει στον `parent` πίνακα για να μπορέσει να εισαχθεί στην στήλη με τα `foreign keys`.

![foreign_key_works](https://user-images.githubusercontent.com/93468476/153776228-88f5388e-9c0c-4092-a444-1139f0aeb68c.png)


Υπάρχουν όμως και περιπτώσεις όπου τα references δεν είναι σωστά δωσμένα από τον χρήστη. Σε κάθε περίπτωση εμφανίζεται σχετικό μύνημα στον χρήστη.

Μερικές περιπτώσεις όπου υπάρχει λάθος στα references κατά την δημιουργία ενός πίνακα:

![foreign_key_doesnt_work](https://user-images.githubusercontent.com/93468476/153775818-f11b814f-c5fb-49a6-8513-23c630a2b7b8.png)

Εδώ ο χρήστης προσπάθησε να εισάγει μία τιμή στον πίνακα. Η τιμή `4` όμως δεν υπάρχει στην στήλη του `parent` πίνακα, οπότε απορρίπτεται και εμφανίζεται σχετικό μήνυμα.

![foreign_key_doesnt_work2](https://user-images.githubusercontent.com/93468476/153775875-4f5b8dbe-718c-4646-850c-30c935507e65.png)

Σε αυτή την περίπτωση ο χρήστης προσπαθεί να δημιουργήσει έναν πίνακα και στην στήλη του `foreign key` προσπαθεί να κάνει `reference` μία στήλη από τον `parent` πίνακα (students) η οποία δεν υπάρχει. Πάλι εμφανίζεται σχετικό μήνυμα.

![foreign_key_doesnt_work3](https://user-images.githubusercontent.com/93468476/153775944-4cc4d969-5e7f-4f30-89a8-ca26e28c30d5.png)

Σε αυτή την περίτπωση ο χρήστης προσπαθεί πάλι να δημιουργήσει έναν πίνακα αλλά αυτή την φορά παρέχει στην στήλη `foreign key` ένα `reference` έναν πίνακα ο οποίο δεν υπάρχει. Οπότε του εμφανίζεται αντίστοιχο μήνυμα.

Σε κάθε στήλη η οποία είναι `foreign key` έχουμε βάλει το tag `#FK#` όπως γίνεται και με το `primary key`, όπως φαίνεται εδώ:

![showing_fk](https://user-images.githubusercontent.com/93468476/153776812-860f9afb-5a5a-4433-b873-2dc99998a932.png)


* Για το #83 έπρεπε να δημιουργήσουμε τους αλγορίθμους INLJ (index nested loop join) καθώς και SMJ (sort merge join). Ο κάθε αλγόριθμος τρέχει σε διαφορετική περίπτωση και γι αυτό ο ακριβώς τον λόγο δημιουργήσαμε μία νέα συνάρτηση `evaluate_join_method` η οποία κρίνει την περίπτωση και μέσω αυτής αποφασίζεται ποιος αλγόριθμος θα τρέξει. Ο SMJ για παράδειγμα είναι μόνο για περιπτώσεις `EQUI JOIN`.

 Μικρά παραδείγματα:
 
 ```
 create table other(sid int primary key, val int);
 
 insert into other values(1, 13000);
insert into other values(3, 15000);
insert into other values(6, 14000);
insert into other values(7, 16000);

create table test1(id int, val int);
insert into test1 values(1, 15);
insert into test1 values(2, 18);
insert into test1 values(3, 11);

create table test2(id int, name str);
insert into test2 values(1, mary);
insert into test2 values(3, bill);
insert into test2 values(14, jason);
 ```
 *  **INLJ** :
 
 ```
 select * from test1 inner join other on id = sid;
 ```
 
![inlj_example](https://user-images.githubusercontent.com/93468476/153776472-2311853c-6293-4680-b243-03e9b638738f.png)

Για να μπορέσει να λειτουργήσει σωστά ο INLJ πρέπει ο δεξί πίνακας που παρέχει ο χρήστης στο `join query` του να έχει `index`. Επειδή το index φτιάχνεται πάνω στο `primary key` του πίνακα σημαίνει ότι πρέπει να έχει και primary key. Αν δεν έχει index δημιουργούμε index αυτόματα για να μπορέσει να τρέξει ο αλγόριθμος.

* **SMJ** :
 
 ```
select * from test1 inner join test2 on id=id;
 ```
 
![smj_example](https://user-images.githubusercontent.com/93468476/153776534-de27a8fd-3277-44c4-b186-442b816fb31a.png)

Δεν έχουμε αλλάξει τίποτα στην σύνταξη των `inner join queries` καθώς όλα γίνονται στο backend, ο χρήστης όμως γνωρίζει ποιος αλγόριθμος χρησιμοποιήθηκε καθώς εμφανίζεται το όνομα του πριν την εμφάνιση του τελικού αποτελέσματος. 