### PR TITLE
Justacid2

### DIFF
--- a/mdb.py
+++ b/mdb.py
@@ -160,7 +160,10 @@ def interpret(query):
                      'delete from': ['delete from', 'where'],
                      'update table': ['update table', 'set', 'where'],
                      'create index': ['create index', 'on', 'using'],
-                     'drop index': ['drop index']
+                     'drop index': ['drop index'],
+                     'start transaction': ['start transaction'],
+                     'commit': ['commit'],
+                     'rollback': ['rollback']
                      }
 
     if query[-1]!=';':

--- a/mdb.py
+++ b/mdb.py
@@ -161,7 +161,7 @@ def interpret(query):
                      'update table': ['update table', 'set', 'where'],
                      'create index': ['create index', 'on', 'using'],
                      'drop index': ['drop index'],
-                     'start transaction': ['start transaction'],
+                     'begin': ['begin'],
                      'commit': ['commit'],
                      'rollback': ['rollback']
                      }

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -22,60 +22,37 @@ class Database:
     Main Database class, containing tables.
     '''
 
-    from __future__ import annotations
-    import pickle
-    from table import Table
-    from time import sleep, localtime, strftime
-    import os, sys
-    from btree import Btree
-    import shutil
-    from misc import split_condition
-    import logging
-    import warnings
-    import readline
-    from tabulate import tabulate
-
-    # sys.setrecursionlimit(100)
-
-    # Clear command cache (journal)
-    readline.clear_history()
-
-    class Database:
-        '''
-        Main Database class, containing tables.
-        '''
-
-        def __init__(self, name, load=True):
-            self.tables = {}
-            self._name = name
-            # flag for when transaction initiation starts
-            self.save_state = False
-            self.savedir = f'dbdata/{name}_db'
-            # to keep locked tables allowing us to unlock them at the end of the transaction
-            self.transaction_locks = []
-            if load:
-                try:
-                    self.load_database()
-                    logging.info(f'Loaded "{name}".')
-                    for i in self.tables.keys():
-                        if not self.is_locked(i):
-                            self.unlock_table(i, True)
-                    return
-                except pickle.PickleError:
-                    warnings.warn(f'Database "{name}" does not exist. Creating new.')
-                except:
-                    warnings.warn('a table is locked')
-                    return
+    def __init__(self, name, load=True):
+        self.tables = {}
+        self._name = name
+        # flag for when transaction initiation starts
+        self.save_state = False
+        self.savedir = f'dbdata/{name}_db'
+        # to keep locked tables allowing us to unlock them at the end of the transaction
+        self.transaction_locks = []
+        if load:
+            try:
+                self.load_database()
+                logging.info(f'Loaded "{name}".')
+                for i in self.tables.keys():
+                    if not self.is_locked(i):
+                        self.unlock_table(i, True)
+                return
+            except pickle.PickleError:
+                warnings.warn(f'Database "{name}" does not exist. Creating new.')
+            except:
+                warnings.warn('a table is locked')
+                return
 
             # create dbdata directory if it doesnt exist
-            if not os.path.exists('dbdata'):
-                os.mkdir('dbdata')
+        if not os.path.exists('dbdata'):
+            os.mkdir('dbdata')
 
-            # create new dbs save directory
-            try:
-                os.mkdir(self.savedir)
-            except:
-                pass
+        # create new dbs save directory
+        try:
+            os.mkdir(self.savedir)
+        except:
+            pass
 
         # create all the meta tables
         self.create_table('meta_length', 'table_name,no_of_rows', 'str,int')


### PR DESCRIPTION
Issue https://github.com/DataStories-UniPi/miniDB/issues/82

Για το issue 82 έχουμε εφαρμόσει το ACID, και χτίσαμε τα functions: start_transaction,rollback,commit,unlock_phase
καθώς και αλλάξαμε ήδη υπάρχουσες συναρτήσεις ετσι ώστε να είναι πλήρης η λειτουργεία
start_transaction: Η συνάρτηση που ξεικινάει ένα transaction αν υπαρχει ήδη καποιο transaction εμφανίζει error.Σταματάει ,με την χρήση ενός flag(save_state), της συναρτήσεις save_database και load_database
rollback:Αν ο χρήστης θέλει να ανεραίσει της αλλάγες, κανει το flag false,ξεκλειδώνει τα τραπέζια και φορτώνει απο τον δίσκο την βάση, που ειναι στην κατάσταση που ήταν πριν το transaction(load_database)
commit:Αν ο χρήστης θέλει να σώσει τις αλλαγές του, κάνει το flag false,ξεκλειδώνει τα τραπέζια και σώζει τις αλλαγές στον δίσκο(save_database)
στις ήδη υπάρχουσές συναρτήσεις έχουμε προσθέσει ενα clause στο if πριν ξεκλειδωθούν που ελέγχει αν έχει ξεκινήσει transaction.Αν έχει τότε το τραπέζι δεν ξεκλειδώνεται και προστήθετε το όνομα του σε μια λίστα transaction_locks, σιγουρεύοντας την ατομικότητα
unlock_phase: ξεκλειδώνουμε τα τραπεζια που είχαν κλειδωθεί μέσα στο transaction, γνωρίζοντας ποια είναι μέσω της λίστας transaction_locks

Τελος καναμε αλλαγες στο is_locked για να τσεκαρουμε αν το process που εκανε τα logs crashare για να κανουμε unlock τα tables που χρησημοποιουσε