### PR TITLE
ΕΡΓΑΣΙΑ ΣΔΒΔ, Π18148, Π19176

### DIFF
--- a/miniDB/dashboard.py
+++ b/miniDB/dashboard.py
@@ -1,14 +1,8 @@
 import sys
 import os
-
 sys.path.append(f'{os.path.dirname(os.path.dirname(os.path.abspath(__file__)))}/miniDB')
-
 from database import Database
-
-
 db = Database(sys.argv[1])
-
-
 for name in list(db.tables): 
     if sys.argv[2]=='meta' and name[:4]!='meta':
         continue

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -422,7 +422,7 @@ class Database:
         self.tables['meta_insert_stack'].tropopoisi_seiras(nea_stoiva, 'indexes', f'table_name={onoma_pinaka}')
 
     # indexes
-    def create_index(self, index_name, onoma_pinaka, onoma_stilis, typos_eurethriou): #Index in a specific column of the table
+    def create_index(self, index_name, onoma_pinaka, onoma_stilis, typos_eurethriou): #Enarxi deuterou erotimatos
         if onoma_pinaka not in self.tables:   #Non-existing table
             raise Exception('Den einai dynath h dhmiourgia eurethriou se pinaka pou den yparxei.')
         if onoma_stilis not in self.tables[onoma_pinaka].column_names:   #Non-existing column
@@ -441,7 +441,7 @@ class Database:
         else:
             raise Exception('Hdh yparxei eurethrio me auto to onoma.')
 
-    def kataskeui_euretiriou(self, onoma_pinaka, index_name, onoma_stilis):  #Create Btree in the primary_key of the table specified
+    def kataskeui_euretiriou(self, onoma_pinaka, index_name, onoma_stilis):  #Kai me b-dendro
         b_dendro = Btree(3)  
         for idx, key in enumerate(self.tables[onoma_pinaka].column_by_name(onoma_stilis)):
             if key is None:
@@ -451,7 +451,7 @@ class Database:
         print('To eftiaxa to btree eurethrio.')
         return
 
-    def ftiaxe_hash_euretirio(self, onoma_pinaka, index_name, onoma_stilis):
+    def ftiaxe_hash_euretirio(self, onoma_pinaka, index_name, onoma_stilis): #Kai me eurethrio katakermatismou
         mhkos_grammhs = len(self.tables[onoma_pinaka].data)
         hm = {}
         hm[0] = {}

--- a/miniDB/database.py
+++ b/miniDB/database.py
@@ -220,9 +220,9 @@ class Database:
             all written as parameters, plus the boolean variable distinct.
         '''
         if condition is not None:
-            if "BETWEEN" in condition.split() or "between" in condition.split():#Does the condition contain between?
+            if "BETWEEN" in condition.split() or "between" in condition.split(): #Epitelous leitourgise kai me to BETWEEN, meta apo pollh prospatheia
                 condition_column = condition.split(" ")[0]
-            elif "NOT" in condition.split() or "not" in condition.split():#Looking for condition with NOT operator
+            elif "NOT" in condition.split() or "not" in condition.split(): #I periptosi tou telesti NOT
                 condition_column = condition.split(" ")[0]
             elif "AND" in condition.split() or "and" in condition.split() or "OR" in condition.split() or "or" in condition.split():#Looking for condition containing AND or OR
                 condition_column = condition.split(" ")[0]

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -3,577 +3,442 @@ from tabulate import tabulate
 import pickle
 import os
 import sys
-
 sys.path.append(f'{os.path.dirname(os.path.dirname(os.path.abspath(__file__)))}/miniDB')
-
-from misc import get_op, split_condition
+from misc import get_op, split_condition , reverse_op
 
 
 class Table:
-    '''
-    Table object represents a table inside a database
-
-    A Table object can be created either by assigning:
-        - a table name (string)
-        - column names (list of strings)
-        - column types (list of functions like str/int etc)
-        - primary (name of the primary key column)
-
-    OR
-
-        - by assigning a value to the variable called load. This value can be:
-            - a path to a Table file saved using the save function
-            - a dictionary that includes the appropriate info (all the attributes in __init__)
-
-    '''
     def __init__(self, name=None, column_names=None, column_types=None, primary_key=None, load=None):
-
         if load is not None:
-            # if load is a dict, replace the object dict with it (replaces the object with the specified one)
+            # if load is a dict, replace the object dict with it.
             if isinstance(load, dict):
                 self.__dict__.update(load)
                 # self._update()
             # if load is str, load from a file
             elif isinstance(load, str):
-                self._load_from_file(load)
+                self.fortose_apo_arxeio(load)
 
-        # if name, columns_names and column types are not none
+        
         elif (name is not None) and (column_names is not None) and (column_types is not None):
-
-            self._name = name
-
-            if len(column_names)!=len(column_types):
-                raise ValueError('Need same number of column names and types.')
-
-            self.column_names = column_names
-
-            self.columns = []
-
-            for col in self.column_names:
-                if col not in self.__dir__():
-                    # this is used in order to be able to call a column using its name as an attribute.
-                    # example: instead of table.columns['column_name'], we do table.column_name
-                    setattr(self, col, [])
-                    self.columns.append([])
-                else:
-                    raise Exception(f'"{col}" attribute already exists in "{self.__class__.__name__} "class.')
-
-            self.column_types = [eval(ct) if not isinstance(ct, type) else ct for ct in column_types]
-            self.data = [] # data is a list of lists, a list of rows that is.
-
-            # if primary key is set, keep its index as an attribute
-            if primary_key is not None:
-                self.pk_idx = self.column_names.index(primary_key)
-            else:
-                self.pk_idx = None
-
-            self.pk = primary_key
-            # self._update()
+              self._name = name
+              if len(column_names)!=len(column_types):
+                raise ValueError('Apaiteitai idios arithmos grammon kai stilon.')
+              self.column_names = column_names
+              self.columns = []
+              for col in self.column_names:
+                  if col not in self.__dir__():
+                     # this is used in order to be able to call a column using its name as an attribute.
+                     setattr(self, col, [])
+                     self.columns.append([])
+                  else:
+                     raise Exception(f'"{col}" attribute already exists in "{self.__class__.__name__} "class.')
+              self.column_types = [eval(ct) if not isinstance(ct, type) else ct for ct in column_types]
+              self.data = [] # data is a list of lists, a list of rows that is.
+              # if primary key is set, keep its index as an attribute
+              if primary_key is not None:
+                  self.pk_idx = self.column_names.index(primary_key)
+              else:
+                  self.pk_idx = None
+              self.pk = primary_key
+            
 
     # if any of the name, columns_names and column types are none. return an empty table object
 
-    def column_by_name(self, column_name):
-        return [row[self.column_names.index(column_name)] for row in self.data]
+    def column_by_name(self, onoma_stilis):
+        return [row[self.column_names.index(onoma_stilis)] for row in self.data]
 
 
-    def _update(self):
-        '''
-        Update all the available columns with the appended rows.
-        '''
+    def _update(self): #Updates the columns with the appended rows.
         self.columns = [[row[i] for row in self.data] for i in range(len(self.column_names))]
         for ind, col in enumerate(self.column_names):
             setattr(self, col, self.columns[ind])
 
     def _cast_column(self, column_name, cast_type):
         '''
-        Cast all values of a column using a specified type.
-
         Args:
             column_name: string. The column that will be casted.
             cast_type: type. Cast type (do not encapsulate in quotes).
         '''
         # get the column from its name
-        column_idx = self.column_names.index(column_name)
+        index_stilis = self.column_names.index(column_name)
         # for every column's value in each row, replace it with itself but casted as the specified type
         for i in range(len(self.data)):
-            self.data[i][column_idx] = cast_type(self.data[i][column_idx])
+            self.data[i][index_stilis] = cast_type(self.data[i][index_stilis])
         # change the type of the column
-        self.column_types[column_idx] = cast_type
-        # self._update()
+        self.column_types[index_stilis] = cast_type
+        
 
-
-    def _insert(self, row, insert_stack=[]):
-        '''
-        Insert row to table.
-
-        Args:
-            row: list. A list of values to be inserted (will be casted to a predifined type automatically).
-            insert_stack: list. The insert stack (empty by default).
-        '''
-        if len(row)!=len(self.column_names):
-            raise ValueError(f'ERROR -> Cannot insert {len(row)} values. Only {len(self.column_names)} columns exist')
-
-        for i in range(len(row)):
+    def _insert(self, seira, stoiva=[]):
+        if len(seira)!=len(self.column_names):
+            raise ValueError(f'Den ginetai na eisaxthoun {len(seira)} times. Yparxoun {len(self.column_names)} sthles')
+        for i in range(len(seira)):
             # for each value, cast and replace it in row.
             try:
-                row[i] = self.column_types[i](row[i])
+                seira[i] = self.column_types[i](seira[i])
             except ValueError:
-                if row[i] != 'NULL':
-                    raise ValueError(f'ERROR -> Value {row[i]} of type {type(row[i])} is not of type {self.column_types[i]}.')
-            except TypeError as exc:
-                if row[i] != None:
-                    print(exc)
-
+                if seira[i] != 'NULL':
+                    raise ValueError(f'I timi {seira[i]} typou {type(seira[i])} den einai ston sosto typo {self.column_types[i]}.')
+            except TypeError as eksairesi:
+                if seira[i] != None:
+                    print(eksairesi)
             # if value is to be appended to the primary_key column, check that it doesnt alrady exist (no duplicate primary keys)
-            if i==self.pk_idx and row[i] in self.column_by_name(self.pk):
-                raise ValueError(f'## ERROR -> Value {row[i]} already exists in primary key column.')
-            elif i==self.pk_idx and row[i] is None:
-                raise ValueError(f'ERROR -> The value of the primary key cannot be None.')
+            if i==self.pk_idx and seira[i] in self.column_by_name(self.pk):
+                raise ValueError(f'## {seira[i]} yparxei hdh sthn sthlh tou proteuontos kleidiou.')
+            elif i==self.pk_idx and seira[i] is None:
+                raise ValueError(f'Prepei na exei timi to proteuon kleidi.')
 
         # if insert_stack is not empty, append to its last index
-        if insert_stack != []:
-            self.data[insert_stack[-1]] = row
-        else: # else append to the end
-            self.data.append(row)
-        # self._update()
+        if stoiva != []:
+            self.data[stoiva[-1]] = seira
+        else: 
+            self.data.append(seira)
+        
 
-    def _update_rows(self, set_value, set_column, condition):
-        '''
-        Update where Condition is met.
-
-        Args:
-            set_value: string. The provided set value.
-            set_column: string. The column to be altered.
-            condition: string. A condition using the following format:
-                'column[<,<=,=,>=,>]value' or
-                'value[<,<=,=,>=,>]column'.
-                
-                Operatores supported: (<,<=,=,>=,>)
-        '''
-        # parse the condition
-        column_name, operator, value = self._parse_condition(condition)
-
+    def tropopoisi_seiras(self, orise_timi, orise_stili, synthiki):
+        column_name, telestis, value = self.analysi_synthikis(synthiki) #Analysi tis synthikis(parsing)
         # get the condition and the set column
         column = self.column_by_name(column_name)
-        set_column_idx = self.column_names.index(set_column)
-
-        # set_columns_indx = [self.column_names.index(set_column_name) for set_column_name in set_column_names]
+        set_column_index = self.column_names.index(orise_stili)
 
         # for each value in column, if condition, replace it with set_value
         for row_ind, column_value in enumerate(column):
-            if get_op(operator, column_value, value):
-                self.data[row_ind][set_column_idx] = set_value
+            if get_op(telestis, column_value, value):
+                self.data[row_ind][set_column_index] = orise_timi
 
-        # self._update()
-                # print(f"Updated {len(indexes_to_del)} rows")
-
-
-    def _delete_where(self, condition):
+        
+    def diagrafi_opou(self, synthiki):
         '''
-        Deletes rows where condition is met.
-
         Important: delete replaces the rows to be deleted with rows filled with Nones.
         These rows are then appended to the insert_stack.
-
         Args:
             condition: string. A condition using the following format:
                 'column[<,<=,==,>=,>]value' or
                 'value[<,<=,==,>=,>]column'.
-                
-                Operatores supported: (<,<=,==,>=,>)
+                Operators supported: (<,<=,==,>=,>)
         '''
-        column_name, operator, value = self._parse_condition(condition)
-
-        indexes_to_del = []
-
-        column = self.column_by_name(column_name)
-        for index, row_value in enumerate(column):
-            if get_op(operator, row_value, value):
-                indexes_to_del.append(index)
-
-        # we pop from highest to lowest index in order to avoid removing the wrong item
-        # since we dont delete, we dont have to to pop in that order, but since delete is used
-        # to delete from meta tables too, we still implement it.
-
-        for index in sorted(indexes_to_del, reverse=True):
+        column_name, telestis, value = self.analysi_synthikis(synthiki)
+        indexes_pros_diagrafi = []
+        stili = self.column_by_name(column_name)
+        for index, row_value in enumerate(stili):
+            if get_op(telestis, row_value, value):
+                indexes_pros_diagrafi.append(index)
+        
+        for index in sorted(indexes_pros_diagrafi, reverse=True):
             if self._name[:4] != 'meta':
                 # if the table is not a metatable, replace the row with a row of nones
                 self.data[index] = [None for _ in range(len(self.column_names))]
             else:
                 self.data.pop(index)
-
-        # self._update()
-        # we have to return the deleted indexes, since they will be appended to the insert_stack
-        return indexes_to_del
+        return indexes_pros_diagrafi
 
 
-    def _select_where(self, return_columns, condition=None, distinct=False, order_by=None, desc=True, limit=None):
+    def _select_where(self, emfanisi_stilwn, condition=None, distinct=False, order_by=None, desc=True, orion=None): #Returns specific rows and columns where a condition is met
         '''
-        Select and return a table containing specified columns and rows where condition is met.
-
         Args:
             return_columns: list. The columns to be returned.
             condition: string. A condition using the following format:
                 'column[<,<=,==,>=,>]value' or
-                'value[<,<=,==,>=,>]column'.
-                
-                Operatores supported: (<,<=,==,>=,>)
+                'value[<,<=,==,>=,>]column' or
+                'Between , NOT, AND , OR'.
             distinct: boolean. If True, the resulting table will contain only unique rows (False by default).
             order_by: string. A column name that signals that the resulting table should be ordered based on it (no order if None).
-            desc: boolean. If True, order_by will return results in descending order (False by default).
-            limit: int. An integer that defines the number of rows that will be returned (all rows if None).
+            desc: boolean. If True, order_by will return results in descending order.
+            orion: int. An integer that defines the number of rows that will be returned (all rows if None).
         '''
-
-        # if * return all columns, else find the column indexes for the columns specified
-        if return_columns == '*':
+        if emfanisi_stilwn == '*': #Returns all columns
             return_cols = [i for i in range(len(self.column_names))]
         else:
-            return_cols = [self.column_names.index(col.strip()) for col in return_columns.split(',')]
-
-        # if condition is None, return all rows
-        # if not, return the rows with values where condition is met for value
+            return_cols = [self.column_names.index(col.strip()) for col in emfanisi_stilwn.split(',')]
         if condition is not None:
-            column_name, operator, value = self._parse_condition(condition)
-            column = self.column_by_name(column_name)
-            rows = [ind for ind, x in enumerate(column) if get_op(operator, x, value)]
-        else:
+            if "BETWEEN" in condition.split() or "between" in condition.split():
+                split_con = condition.split()
+                if (split_con[3] != 'and'):  
+                    print('Prepei na exei and metaksy ton arithmon.')
+                    exit()
+                else:   
+                    aristeri_timi = split_con[2]  
+                    dexia_timi = split_con[4]  
+                    column_name = split_con[0]
+                    column = self.column_by_name(column_name)
+                    rows = []
+                    if (aristeri_timi.isdigit() and dexia_timi.isdigit()):  
+                        for i, j in enumerate(column):
+                            if int(j) >= int(aristeri_timi) and int(j) <= int(dexia_timi):
+                                rows.append(i)  #if between applies
+                    else:  
+                        print('Den sygkrinontai ta alpharithmitika') #No value other than number accepted
+                        exit()
+            elif "OR" in condition.split() or "or" in condition.split(): #OR operator
+                condition_list = condition.split("OR")
+                condition_list = condition_list[0].split("or")
+                row_lists = []
+                for cond in condition_list: # run every condition seperatly
+                    column_name, telestis, value = self.analysi_synthikis(cond)
+                    column = self.column_by_name(column_name)
+                    row_lists.append([ind for ind, x in enumerate(column) if get_op(telestis, x, value)])
+                rows = []
+                for l in row_lists: # move all rows into one list
+                    for row in l:
+                        if not(row in rows):
+                            rows.append(row)
+            elif "AND" in condition.split() or "and" in condition.split(): #AND operator
+                condition_list = condition.split("AND")
+                condition_list = condition_list[0].split("and")
+                row_lists = []
+                for cond in condition_list: # run every condition seperatly
+                    column_name, telestis, value = self.analysi_synthikis(cond)
+                    column = self.column_by_name(column_name)
+                    row_lists.append([ind for ind, x in enumerate(column) if get_op(telestis, x, value)])
+                rows = set(row_lists[0]).intersection(*row_lists) # get the intersection of the seperate conditions
+            elif "NOT" in condition.split() or "not" in condition.split(): #NOT operator
+                condition_list = condition.split("NOT")
+                condition_list = condition_list[0].split("not")                 
+                column_name, telestis, value = self.analysi_synthikis(condition_list[1])
+                column = self.column_by_name(column_name)
+                operator2=reverse_op(telestis)
+                rows = [ind for ind, x in enumerate(column) if get_op(operator2, x, value)]
+            else:
+                column_name, telestis, value = self.analysi_synthikis(condition)
+                column = self.column_by_name(column_name)                
+                rows = [ind for ind, x in enumerate(column) if get_op(telestis, x, value)]
+        else: #If condition is None
             rows = [i for i in range(len(self.data))]
 
-        # copy the old dict, but only the rows and columns of data with index in rows/columns (the indexes that we want returned)
+        # copy the old dict, but only the rows and columns of data with index
         dict = {(key):([[self.data[i][j] for j in return_cols] for i in rows] if key=="data" else value) for key,value in self.__dict__.items()}
-
-        # we need to set the new column names/types and no of columns, since we might
-        # only return some columns
         dict['column_names'] = [self.column_names[i] for i in return_cols]
         dict['column_types']   = [self.column_types[i] for i in return_cols]
-
-        s_table = Table(load=dict)
-
-        s_table.data = list(set(map(lambda x: tuple(x), s_table.data))) if distinct else s_table.data
-
+        pros_emfanisi = Table(load=dict)
+        pros_emfanisi.data = list(set(map(lambda x: tuple(x), pros_emfanisi.data))) if distinct else pros_emfanisi.data
         if order_by:
-            s_table.order_by(order_by, desc)
-
-        # if isinstance(limit, str):
-        #     try:
-        #         k = int(limit)
-        #     except ValueError:
-        #         raise Exception("The value following 'top' in the query should be a number.")
-            
-        #     # Remove from the table's data all the None-filled rows, as they are not shown by default
-        #     # Then, show the first k rows 
-        #     s_table.data.remove(len(s_table.column_names) * [None])
-        #     s_table.data = s_table.data[:k]
-        if isinstance(limit,str):
-            s_table.data = [row for row in s_table.data if any(row)][:int(limit)]
-
-        return s_table
+            pros_emfanisi.order_by(order_by, desc)
+        if isinstance(orion,str):
+            pros_emfanisi.data = [row for row in pros_emfanisi.data if any(row)][:int(orion)]
+        return pros_emfanisi
 
 
-    def _select_where_with_btree(self, return_columns, bt, condition, distinct=False, order_by=None, desc=True, limit=None):
-
-        # if * return all columns, else find the column indexes for the columns specified
+    def epilogi_alla_me_btree(self, return_columns, b_dendro, synthiki, distinct=False, order_by=None, desc=True, orion=None):# Selecting with Btree
         if return_columns == '*':
-            return_cols = [i for i in range(len(self.column_names))]
+            emfanisi_stilwn = [i for i in range(len(self.column_names))]
         else:
-            return_cols = [self.column_names.index(colname) for colname in return_columns]
-
-
-        column_name, operator, value = self._parse_condition(condition)
-
-        # if the column in condition is not a primary key, abort the select
-        if column_name != self.column_names[self.pk_idx]:
-            print('Column is not PK. Aborting')
-
-        # here we run the same select twice, sequentially and using the btree.
-        # we then check the results match and compare performance (number of operation)
+            emfanisi_stilwn = [self.column_names.index(colname) for colname in return_columns]
+        column_name, telestis, value = self.analysi_synthikis(synthiki)
         column = self.column_by_name(column_name)
 
         # sequential
         rows1 = []
-        opsseq = 0
+        operations_sequential = 0
         for ind, x in enumerate(column):
-            opsseq+=1
-            if get_op(operator, x, value):
+            operations_sequential+=1
+            if get_op(telestis, x, value):
                 rows1.append(ind)
 
-        # btree find
-        rows = bt.find(operator, value)
-
+        rows = b_dendro.find(telestis, value)
         try:
-            k = int(limit)
+            arithmos_oriou = int(orion)
         except TypeError:
-            k = None
-        # same as simple select from now on
-        rows = rows[:k]
-        # TODO: this needs to be dumbed down
-        dict = {(key):([[self.data[i][j] for j in return_cols] for i in rows] if key=="data" else value) for key,value in self.__dict__.items()}
-
-        dict['column_names'] = [self.column_names[i] for i in return_cols]
-        dict['column_types']   = [self.column_types[i] for i in return_cols]
-
-        s_table = Table(load=dict)
-
-        s_table.data = list(set(map(lambda x: tuple(x), s_table.data))) if distinct else s_table.data
-
+            arithmos_oriou = None
+        rows = rows[:arithmos_oriou]
+        dict = {(key):([[self.data[i][j] for j in emfanisi_stilwn] for i in rows] if key=="data" else value) for key,value in self.__dict__.items()}
+        dict['column_names'] = [self.column_names[i] for i in emfanisi_stilwn]
+        dict['column_types']   = [self.column_types[i] for i in emfanisi_stilwn]
+        pros_emfanisi = Table(load=dict)
+        pros_emfanisi.data = list(set(map(lambda x: tuple(x), pros_emfanisi.data))) if distinct else pros_emfanisi.data
         if order_by:
-            s_table.order_by(order_by, desc)
+            pros_emfanisi.order_by(order_by, desc)
+        if isinstance(orion,str):
+            pros_emfanisi.data = [row for row in pros_emfanisi.data if row is not None][:int(orion)]
+        return pros_emfanisi
 
-        if isinstance(limit,str):
-            s_table.data = [row for row in s_table.data if row is not None][:int(limit)]
 
-        return s_table
+    def epilogi_alla_me_hash(self, return_columns, hm, synthiki, distinct=False, order_by=None, desc=True, orion=None):  #Selecting with hash
+        if return_columns == '*':
+            emfanisi_stilwn = [i for i in range(len(self.column_names))]
+        else:
+            emfanisi_stilwn = [self.column_names.index(colname) for colname in return_columns]
+        column_name, telestis, value = self.analysi_synthikis(synthiki)
+        rows = []
+        if (telestis == '<' or telestis == '>'):
+            column = self.column_by_name(column_name)
+            # sequential
+            operations_sequential = 0
+            for ind, x in enumerate(column):
+                operations_sequential+=1
+                if get_op(telestis, x, value):
+                    rows.append(ind)
+        else:
+            # hash value
+            athroisma_hash = 0
+            for letter in value:
+                athroisma_hash += ord(letter)
+            hash_index = athroisma_hash % int(hm[0][0][0])
+            # find in dictionary with hash_index
+            for item in hm[hash_index]:
+                if hm[hash_index][item][0] == hm[0][0][0]:
+                    continue
+                if hm[hash_index][item][1] == value:
+                    rows.append(hm[hash_index][item][0])
+            
+        try:
+            arithmos_oriou = int(orion)
+        except TypeError:
+            arithmos_oriou = None
+        rows = rows[:arithmos_oriou]
+        dict = {(key):([[self.data[i][j] for j in emfanisi_stilwn] for i in rows] if key=="data" else value) for key,value in self.__dict__.items()}
+        dict['column_names'] = [self.column_names[i] for i in emfanisi_stilwn]
+        dict['column_types']   = [self.column_types[i] for i in emfanisi_stilwn]
+        pros_emfanisi = Table(load=dict)
+        pros_emfanisi.data = list(set(map(lambda x: tuple(x), pros_emfanisi.data))) if distinct else pros_emfanisi.data
+        if order_by:
+            pros_emfanisi.order_by(order_by, desc)
+        if isinstance(orion,str):
+            pros_emfanisi.data = [row for row in pros_emfanisi.data if row is not None][:int(orion)]
+        return pros_emfanisi
 
-    def order_by(self, column_name, desc=True):
-        '''
-        Order table based on column.
-
-        Args:
-            column_name: string. Name of column.
-            desc: boolean. If True, order_by will return results in descending order (False by default).
-        '''
-        column = [val if val is not None else 0 for val in self.column_by_name(column_name)]
-        idx = sorted(range(len(column)), key=lambda k: column[k], reverse=desc)
-        # print(idx)
+    
+    def order_by(self, onoma_stilis, desc=True):
+        stili = self.column_by_name(onoma_stilis)
+        idx = sorted(range(len(stili)), key=lambda k: stili[k], reverse=desc)
         self.data = [self.data[i] for i in idx]
-        # self._update()
-
-
-    def _general_join_processing(self, table_right:Table, condition, join_type):
-        '''
-        Performs the processes all the join operations need (regardless of type) so that there is no code repetition.
-
-        Args:
-            condition: string. A condition using the following format:
-                'column[<,<=,==,>=,>]value' or
-                'value[<,<=,==,>=,>]column'.
-                
-                Operators supported: (<,<=,==,>=,>)
-        '''
+        
+    def _general_join_processing(self, table_right:Table, synthiki, join_type):
         # get columns and operator
-        column_name_left, operator, column_name_right = self._parse_condition(condition, join=True)
+        column_name_left, telestis, column_name_right = self.analysi_synthikis(synthiki, join=True)
         # try to find both columns, if you fail raise error
-
-        if(operator != '=' and join_type in ['left','right','full']):
+        if(telestis != '=' and join_type in ['left','right','full']):
             class CustomFailException(Exception):
                 pass
-            raise CustomFailException('Outer Joins can only be used if the condition operator is "=".\n')
+            raise CustomFailException('Den ginetai outer join xoris "=". ')
 
         try:
-            column_index_left = self.column_names.index(column_name_left)
+            index_stilis_aristerou_pinaka = self.column_names.index(column_name_left)
         except:
-            raise Exception(f'Column "{column_name_left}" dont exist in left table. Valid columns: {self.column_names}.')
+            raise Exception(f'H sthlh "{column_name_left}" den yparxei ston aristero pinaka.')
 
         try:
-            column_index_right = table_right.column_names.index(column_name_right)
+            index_stilis_dexiou_pinaka = table_right.column_names.index(column_name_right)
         except:
-            raise Exception(f'Column "{column_name_right}" dont exist in right table. Valid columns: {table_right.column_names}.')
-
+            raise Exception(f'H sthlh "{column_name_right}" den yparxei ston dexio pinaka.')
         # get the column names of both tables with the table name in front
-        # ex. for left -> name becomes left_table_name_name etc
-        left_names = [f'{self._name}.{colname}' if self._name!='' else colname for colname in self.column_names]
-        right_names = [f'{table_right._name}.{colname}' if table_right._name!='' else colname for colname in table_right.column_names]
-
-        # define the new tables name, its column names and types
-        join_table_name = ''
-        join_table_colnames = left_names+right_names
-        join_table_coltypes = self.column_types+table_right.column_types
-        join_table = Table(name=join_table_name, column_names=join_table_colnames, column_types= join_table_coltypes)
-
-        return join_table, column_index_left, column_index_right, operator
+        onomata_stilon_aristerou_pinaka = [f'{self._name}.{colname}' if self._name!='' else colname for colname in self.column_names]
+        onomata_stilon_dexiou_pinaka = [f'{table_right._name}.{colname}' if table_right._name!='' else colname for colname in table_right.column_names]
+        # define the new table
+        onoma_enomenou_pinaka = ''
+        stiles_enomenou_pinaka = onomata_stilon_aristerou_pinaka+onomata_stilon_dexiou_pinaka
+        typoi_stilon_enomenou_pinaka = self.column_types+table_right.column_types
+        join_table = Table(name=onoma_enomenou_pinaka, column_names=stiles_enomenou_pinaka, column_types= typoi_stilon_enomenou_pinaka)
+        return join_table, index_stilis_aristerou_pinaka, index_stilis_dexiou_pinaka, telestis
 
 
-    def _inner_join(self, table_right: Table, condition):
-        '''
-        Join table (left) with a supplied table (right) where condition is met.
-
-        Args:
-            condition: string. A condition using the following format:
-                'column[<,<=,==,>=,>]value' or
-                'value[<,<=,==,>=,>]column'.
-                
-                Operators supported: (<,<=,==,>=,>)
-        '''
-        join_table, column_index_left, column_index_right, operator = self._general_join_processing(table_right, condition, 'inner')
-
+    def _inner_join(self, table_right: Table, condition): #Inner join depending on the condition.
+        join_table, index_stilis_aristerou_pinaka, index_stilis_dexiou_pinaka, telestis = self._general_join_processing(table_right, condition, 'inner')
         # count the number of operations (<,> etc)
-        no_of_ops = 0
-        # this code is dumb on purpose... it needs to illustrate the underline technique
-        # for each value in left column and right column, if condition, append the corresponding row to the new table
+        metritis_teleston = 0
         for row_left in self.data:
-            left_value = row_left[column_index_left]
+            aristeri_timi = row_left[index_stilis_aristerou_pinakat]
             for row_right in table_right.data:
-                right_value = row_right[column_index_right]
-                if(left_value is None and right_value is None):
+                dexia_timi = row_right[index_stilis_dexiou_pinaka]
+                if(aristeri_timi is None and dexia_timi is None):
                     continue
-                no_of_ops+=1
-                if get_op(operator, left_value, right_value): #EQ_OP
+                metritis_teleston+=1 #Add the row to the table
+                if get_op(telestis, aristeri_timi, dexia_timi): 
                     join_table._insert(row_left+row_right)
-
         return join_table
     
-    def _left_join(self, table_right: Table, condition):
-        '''
-        Perform a left join on the table with the supplied table (right).
-
-        Args:
-            condition: string. A condition using the following format:
-                'column[<,<=,==,>=,>]value' or
-                'value[<,<=,==,>=,>]column'.
-                
-                Operators supported: (<,<=,==,>=,>)
-        '''
-        join_table, column_index_left, column_index_right, operator = self._general_join_processing(table_right, condition, 'left')
-
-        right_column = table_right.column_by_name(table_right.column_names[column_index_right])
-        right_table_row_length = len(table_right.column_names)
-
+    def enosi_apo_aristera(self, table_right: Table, condition): #Performs left join of the table.
+        join_table, index_stilis_aristerou_pinaka, index_stilis_dexiou_pinaka, operator = self._general_join_processing(table_right, condition, 'left')
+        dexia_stili = table_right.column_by_name(table_right.column_names[index_stilis_dexiou_pinaka])
+        mhkos_grammhs_dexiou_pinaka = len(table_right.column_names)
         for row_left in self.data:
-            left_value = row_left[column_index_left]
-            if left_value is None:
+            aristeri_timi = row_left[index_stilis_aristerou_pinaka]
+            if aristeri_timi is None:
                 continue
-            elif left_value not in right_column:
-                join_table._insert(row_left + right_table_row_length*["NULL"])
+            elif aristeri_timi not in dexia_stili:
+                join_table._insert(row_left + mhkos_grammhs_dexiou_pinaka*["NULL"])
             else:
                 for row_right in table_right.data:
-                    right_value = row_right[column_index_right]
-                    if left_value == right_value:
+                    dexia_timi = row_right[index_stilis_dexiou_pinaka]
+                    if aristeri_timi == dexia_timi:
                         join_table._insert(row_left + row_right)
-
         return join_table
 
-    def _right_join(self, table_right: Table, condition):
-        '''
-        Perform a right join on the table with the supplied table (right).
-
-        Args:
-            condition: string. A condition using the following format:
-                'column[<,<=,==,>=,>]value' or
-                'value[<,<=,==,>=,>]column'.
-                
-                Operators supported: (<,<=,==,>=,>)
-        '''
-        join_table, column_index_left, column_index_right, operator = self._general_join_processing(table_right, condition, 'right')
-
-        left_column = self.column_by_name(self.column_names[column_index_left])
-        left_table_row_length = len(self.column_names)
-
+    def enosi_apo_dexia(self, table_right: Table, condition): #Performs right join of the table.
+        join_table, index_stilis_aristerou_pinaka, index_stilis_dexiou_pinaka, operator = self._general_join_processing(table_right, condition, 'right')
+        aristeri_stili = self.column_by_name(self.column_names[index_stilis_aristerou_pinaka])
+        mhkos_grammhs_aristerou_pinaka = len(self.column_names)
         for row_right in table_right.data:
-            right_value = row_right[column_index_right]
-            if right_value is None:
+            dexia_timi = row_right[index_stilis_dexiou_pinaka]
+            if dexia_timi is None:
                 continue
-            elif right_value not in left_column:
-                join_table._insert(left_table_row_length*["NULL"] + row_right)
+            elif dexia_timi not in aristeri_stili:
+                join_table._insert(mhkos_grammhs_aristerou_pinaka*["NULL"] + row_right)
             else:
                 for row_left in self.data:
-                    left_value = row_left[column_index_left]
-                    if left_value == right_value:
+                    aristeri_timi = row_left[index_stilis_aristerou_pinaka]
+                    if aristeri_timi == dexia_timi:
                         join_table._insert(row_left + row_right)
-
         return join_table
     
-    def _full_join(self, table_right: Table, condition):
-        '''
-        Perform a full join on the table with the supplied table (right).
-
-        Args:
-            condition: string. A condition using the following format:
-                'column[<,<=,==,>=,>]value' or
-                'value[<,<=,==,>=,>]column'.
-                
-                Operators supported: (<,<=,==,>=,>)
-        '''
-        join_table, column_index_left, column_index_right, operator = self._general_join_processing(table_right, condition, 'full')
-
-        right_column = table_right.column_by_name(table_right.column_names[column_index_right])
-        left_column = self.column_by_name(self.column_names[column_index_left])
-
-        right_table_row_length = len(table_right.column_names)
-        left_table_row_length = len(self.column_names)
-        
+    def pliris_enosi(self, table_right: Table, condition): #Performs full join of the table,according to a specific condition.
+        join_table, index_stilis_aristerou_pinaka, index_stilis_dexiou_pinaka, telestis = self._general_join_processing(table_right, condition, 'full')
+        dexia_stili = table_right.column_by_name(table_right.column_names[index_stilis_dexiou_pinaka])
+        aristeri_stili = self.column_by_name(self.column_names[index_stilis_aristerou_pinaka])
+        mhkos_grammhs_dexiou_pinaka = len(table_right.column_names)
+        mhkos_grammhs_aristerou_pinaka = len(self.column_names)
         for row_left in self.data:
-            left_value = row_left[column_index_left]
-            if left_value is None:
+            aristeri_timi = row_left[index_stilis_aristerou_pinaka]
+            if aristeri_timi is None:
                 continue
-            if left_value not in right_column:
-                join_table._insert(row_left + right_table_row_length*["NULL"])
+            if aristeri_timi not in dexia_stili:
+                join_table._insert(row_left + mhkos_grammhs_dexiou_pinaka*["NULL"])
             else:
                 for row_right in table_right.data:
-                    right_value = row_right[column_index_right]
-                    if left_value == right_value:
+                    dexia_timi = row_right[index_stilis_dexiou_pinaka]
+                    if aristeri_timi == dexia_timi:
                         join_table._insert(row_left + row_right)
-
         for row_right in table_right.data:
-            right_value = row_right[column_index_right]
-
-            if right_value is None:
+            dexia_timi = row_right[index_stilis_dexiou_pinaka]
+            if dexia_timi is None:
                 continue
-            elif right_value not in left_column:
-                join_table._insert(left_table_row_length*["NULL"] + row_right)
-
+            elif dexia_timi not in aristeri_stili:
+                join_table._insert(mhkos_grammhs_aristerou_pinaka*["NULL"] + row_right)
         return join_table
 
-    def show(self, no_of_rows=None, is_locked=False):
-        '''
-        Print the table in a nice readable format.
-
-        Args:
-            no_of_rows: int. Number of rows.
-            is_locked: boolean. Whether it is locked (False by default).
-        '''
-        output = ""
-        # if the table is locked, add locked keyword to title
-        if is_locked:
-            output += f"\n## {self._name} (locked) ##\n"
+    def show(self, plithos_grammon=None, einai_kleidomeno=False): #Show the table!
+        pros_emfanisi = ""
+        if einai_kleidomeno:
+            pros_emfanisi += f"\n## {self._name} kleidomeno ##\n"
         else:
-            output += f"\n## {self._name} ##\n"
-
+            pros_emfanisi += f"\n## {self._name} ##\n"
         # headers -> "column name (column type)"
         headers = [f'{col} ({tp.__name__})' for col, tp in zip(self.column_names, self.column_types)]
         if self.pk_idx is not None:
             # table has a primary key, add PK next to the appropriate column
             headers[self.pk_idx] = headers[self.pk_idx]+' #PK#'
-        # detect the rows that are no tfull of nones (these rows have been deleted)
-        # if we dont skip these rows, the returning table has empty rows at the deleted positions
-        non_none_rows = [row for row in self.data if any(row)]
-        # print using tabulate
-        print(tabulate(non_none_rows[:no_of_rows], headers=headers)+'\n')
+        # detect the rows that are not full of nones
+        mh_kenes_seires = [row for row in self.data if any(row)]
+        print(tabulate(mh_kenes_seires[:plithos_grammon], headers=headers)+'\n')
 
 
-    def _parse_condition(self, condition, join=False):
+    def analysi_synthikis(self, synthiki, join=False):
         '''
-        Parse the single string condition and return the value of the column and the operator.
-
-        Args:
-            condition: string. A condition using the following format:
-                'column[<,<=,==,>=,>]value' or
-                'value[<,<=,==,>=,>]column'.
-                
-                Operatores supported: (<,<=,==,>=,>)
+        Args:(other than the condition)
             join: boolean. Whether to join or not (False by default).
         '''
-        # if both_columns (used by the join function) return the names of the names of the columns (left first)
+        # if the function uses both columns, then return the names of the columns (left first)
         if join:
-            return split_condition(condition)
+            return split_condition(synthiki)
 
-        # cast the value with the specified column's type and return the column name, the operator and the casted value
-        left, op, right = split_condition(condition)
-        if left not in self.column_names:
-            raise ValueError(f'Condition is not valid (cant find column name)')
-        coltype = self.column_types[self.column_names.index(left)]
+        # cast the value with the specified column's type
+        aristero, op, dexi = split_condition(synthiki)
+        if aristero not in self.column_names:
+            raise ValueError(f'Synthiki mh egkurh (den vrisko tin stili pou mou les)')
+        typos_sthlhs = self.column_types[self.column_names.index(aristero)]
+        return aristero, op, typos_sthlhs(dexi)
 
-        return left, op, coltype(right)
 
-
-    def _load_from_file(self, filename):
-        '''
-        Load table from a pkl file (not used currently).
-
-        Args:
-            filename: string. Name of pkl file.
-        '''
-        f = open(filename, 'rb')
-        tmp_dict = pickle.load(f)
-        f.close()
-
-        self.__dict__.update(tmp_dict.__dict__)
+    def fortose_apo_arxeio(self, arxeiouonoma): #Loads from a .pkl file 
+        arxeio_pros_anoigma = open(arxeiouonoma, 'rb')
+        fortoma = pickle.load(arxeio_pros_anoigma)
+        arxeio_pros_anoigma.close()
+        self.__dict__.update(fortoma.__dict__)

--- a/miniDB/table.py
+++ b/miniDB/table.py
@@ -55,7 +55,7 @@ class Table:
 
     def _cast_column(self, column_name, cast_type):
         '''
-        Args:
+        Xrhsima:
             column_name: string. The column that will be casted.
             cast_type: type. Cast type (do not encapsulate in quotes).
         '''
@@ -108,9 +108,7 @@ class Table:
         
     def diagrafi_opou(self, synthiki):
         '''
-        Important: delete replaces the rows to be deleted with rows filled with Nones.
-        These rows are then appended to the insert_stack.
-        Args:
+        Xrhsima:
             condition: string. A condition using the following format:
                 'column[<,<=,==,>=,>]value' or
                 'value[<,<=,==,>=,>]column'.
@@ -125,16 +123,15 @@ class Table:
         
         for index in sorted(indexes_pros_diagrafi, reverse=True):
             if self._name[:4] != 'meta':
-                # if the table is not a metatable, replace the row with a row of nones
                 self.data[index] = [None for _ in range(len(self.column_names))]
             else:
                 self.data.pop(index)
         return indexes_pros_diagrafi
 
 
-    def _select_where(self, emfanisi_stilwn, condition=None, distinct=False, order_by=None, desc=True, orion=None): #Returns specific rows and columns where a condition is met
+    def _select_where(self, emfanisi_stilwn, condition=None, distinct=False, order_by=None, desc=True, orion=None): #To gnosto select...from...where
         '''
-        Args:
+        Xrhsima:
             return_columns: list. The columns to be returned.
             condition: string. A condition using the following format:
                 'column[<,<=,==,>=,>]value' or
@@ -217,7 +214,7 @@ class Table:
         return pros_emfanisi
 
 
-    def epilogi_alla_me_btree(self, return_columns, b_dendro, synthiki, distinct=False, order_by=None, desc=True, orion=None):# Selecting with Btree
+    def epilogi_alla_me_btree(self, return_columns, b_dendro, synthiki, distinct=False, order_by=None, desc=True, orion=None): #Eurethrio b-dendro
         if return_columns == '*':
             emfanisi_stilwn = [i for i in range(len(self.column_names))]
         else:
@@ -251,7 +248,7 @@ class Table:
         return pros_emfanisi
 
 
-    def epilogi_alla_me_hash(self, return_columns, hm, synthiki, distinct=False, order_by=None, desc=True, orion=None):  #Selecting with hash
+    def epilogi_alla_me_hash(self, return_columns, hm, synthiki, distinct=False, order_by=None, desc=True, orion=None):  #I periptosi tou hash
         if return_columns == '*':
             emfanisi_stilwn = [i for i in range(len(self.column_names))]
         else:


### PR DESCRIPTION
Η παρούσα εργασία έγινε σε περιβάλλον των Windows 11, αφού πρώτα κατεβάσαμε το Git Bash από την ιστοσελίδα https://git-scm.com/download/win. Χρειάστηκε να γίνουν ορισμένες τροποποιήσεις στα αρχεία python με τίτλο mdb, dashboard, database και table που προέρχονται από το DataStories-Unipi του GitHub. Οι κώδικες της python γράφτηκαν σε Notepad++, και με αυτούς υλοποιήσαμε το 1ο και το 2ο ερώτημα της άσκησης. 
ΕΡΩΤΗΜΑ 1Ο 
Στόχος του ερωτήματος ήταν να υποστηρίζεται στην miniDB η επιλογή με κάποιον από τους τελεστές BETWEEN, NOT, AND και OR. Μεταβαίνουμε στο αρχείο database.py και στην συνάρτηση select, στο σημείο που γράφεται if condition is not None, μέσα σε αυτό το if βάζουμε ένα if…elif…else με την περίπτωση καθενός από τους παραπάνω τελεστές, και σε κάθε περίπτωση εκτελείται η συνάρτηση. 
Στο αρχείο table : Έγινε έλεγχος ορθότητας για κάθε μία από τις 4 λέξεις, και ανάλογα με την περίπτωση εκτελείται κατά αυτόν τον τρόπο η select_where. Στο σημείο που γράφουμε if condition is not None (line 210) βάζουμε if_elif_else για τους operators. Συγκεκριμένα είπαμε για το BETWEEN να έχει το AND ανάμεσα σε αριθμούς, ο ένας εξ αυτών εκχωρείται στην μεταβλητή aristeri_timi και ο άλλος στην μεταβλητή dexia_timi. Αλλιώς εμφανίζεται μήνυμα, ότι δεν μπορούν να συγκριθούν αλφαριθμητικά(strings). Για το OR γίνεται έλεγχος αν υπάρχει στην συνθήκη, και το αποτέλεσμα εκχωρείται σε έναν πίνακα row_lists. Με ανάλογο τρόπο δουλεύουμε και για τις συναρτήσεις NOT και AND.
Προηγουμένως δημιουργούμε την βάση αφού γράψουμε στο Git Bash τις εντολές cd miniDB και DB=database_name SQL=sql_files/smallRelationsInsertFile.sql python mdb.py. Εμφανίζεται μήνυμα ότι η βάση με το συγκεκριμένο όνομα δεν υπάρχει. Μαζί με τους κύριους πίνακες θα δημιουργηθούν και τα meta_tables.
Δημιουργία της βάσης δεδομένων
![Screenshot_2](https://user-images.githubusercontent.com/61273108/220190470-eaacb1b3-75b9-487c-be5f-00a9e94aff32.png)

 
Εκτέλεση εντολής select με τον τελεστή OR
![Screenshot_3](https://user-images.githubusercontent.com/61273108/220190548-a9c55b9f-403a-42b3-bebd-ae294a5b9bd5.png)

 
Εντολή select με τον τελεστή NOT
![Screenshot_4](https://user-images.githubusercontent.com/61273108/220190585-82038789-3031-4ca6-b45b-1557449d83c7.png)

 
Εντολή select με τον τελεστή BETWEEN
![Screenshot_5](https://user-images.githubusercontent.com/61273108/220190600-4f81891a-7706-4461-b031-f1a44c6b884b.png)

 
Και τέλος, εντολή select με τον τελεστή AND
![Screenshot_6](https://user-images.githubusercontent.com/61273108/220190629-c56aed47-ca51-4b4f-bd64-22f7a4357746.png)

 
Επιπλέον, δοκιμάσαμε απλές εντολές εισαγωγής εγγραφών στον πίνακα, καθώς και δημιουργία νέου πίνακα.
![Screenshot_7](https://user-images.githubusercontent.com/61273108/220190725-b84f6728-5f91-48da-8f4f-b4137a4b4485.png)
![Screenshot_8](https://user-images.githubusercontent.com/61273108/220190754-87fd38c8-5348-4270-881e-e4e189836e40.png)

 
 

ΕΡΩΤΗΜΑ 2Ο 
Στόχος του δεύτερου ερωτήματος ήταν να φτιάξουμε ευρετήριο, τόσο σε μορφή Β δένδρου, όσο και σε μορφή ευρετηρίου κατακερματισμού. Αρχικά έγιναν ορισμένες τροποποιήσεις στο αρχείο mdb.py ώστε να υποστηρίζονται και οι δύο μορφές ευρετηρίων. Στην συνάρτηση diermineia (line 145 to 170) στην μεταβλητή kw_per_action, η οποία αποτελεί πίνακα με τις λέξεις που χρησιμοποιούμε ανάλογα με την ενέργεια, προσθέτουμε και το create_index, και το drop_index. Συνεχίζουμε στην συνάρτηση dimiourgia_protou_planou(line 39) όπου βάζουμε ένα if energeia = ‘create index’ για την περίπτωση δημιουργίας ευρετηρίου και φτιάχνουμε το λεξικό που θα εκτελεστεί στην def ektelesi_lexikou(dic) (line 172).
Για την δημιουργία του B-tree ευρετηρίου μεταβήκαμε στο αρχείο database.py και προσθέσαμε επιπλέον όρισμα index_type στην συνάρτηση create_index(line 557). Γίνεται έλεγχος για το αν υπάρχει ο πίνακας ή η στήλη επί της οποίας θέλουμε το ευρετήριο, και αν δεν υπάρχει εμφανίζεται μήνυμα λάθους.  Κατόπιν αυτού δημιουργείται το ευρετήριο με κλήση της συνάρτησης _construct_index(line 577). Αν υπάρχει index με το ίδιο όνομα, προφανώς θα δοθεί μήνυμα στον χρήστη.
Για το ευρετήριο κατακερματισμού καλείται η συνάρτηση _construct_index_hash (line 588). Στην συνάρτηση αυτή παράγεται ο αριθμός των στηλών του πίνακα και δημιουργείται ένα λεξικό. Το άθροισμα του hash αρχικοποιείται ως μηδέν. Για κάθε γράμμα του στοιχείου της στήλης όπου θα γίνει το hash, το μετατρέπουμε σε αριθμό και το προσθέτουμε στο hash_sum. Το hash_index είναι το υπόλοιπο της διαίρεσης του hash_sum με το μήκος της γραμμής του πίνακα. Το sub_dictionary είναι ένα τμήμα του λεξικού που έχουμε , και εισάγουμε σε αυτό ένα νέο hash_index. Πλέον, όταν θέλουμε να κάνουμε επιλογή με index, αυτό θα γίνει με την συνάρτηση _select_where_with_hash που είναι στο αρχείο table.py (line 341).  Σε αυτήν έχουμε βάλει ένα if-else, δηλαδή αν ο τελεστής είναι < ή >, θα εμφανίσει τις ζητούμενες στήλες κατ’ αλφαβητική σειρά. Αλλιώς, ακολουθούμε την ίδια διαδικασία με την _construct_index_hash του αρχείου database.py . Τέλος εξετάσαμε και την περίπτωση της εντολής drop_index, η οποία διαγράφει το ευρετήριο όταν υπάρχει ευρετήριο με το συγκεκριμένο όνομα που πληκτρολογούμε. Αλλιώς εμφανίζεται exception και μήνυμα ότι το ευρετήριο δεν υπάρχει. Παρακάτω έχουμε παραδείγματα εκτέλεσης για το δεύτερο ερώτημα.
Όταν το index δεν υπάρχει
 
![Screenshot_9](https://user-images.githubusercontent.com/61273108/220191007-37973c63-64ee-478f-9d33-cf5860a032c8.png)






Δημιουργία index μορφής Btree, το οποίο εισάγεται στον πίνακα meta_indexes. Εμφάνιση και των προηγούμενων indexes.
![Screenshot_10](https://user-images.githubusercontent.com/61273108/220191096-f56eb05e-7047-49e9-a537-0c82fa861b4f.png)

 
Δημιουργία ευρετηρίου μορφής Hash. Για δοκιμή προηγουμένως είχαμε δημιουργήσει και άλλα indexes τα οποία εμφανίζονται.
 
![Screenshot_11](https://user-images.githubusercontent.com/61273108/220191148-fc59695d-c348-4673-aa9c-85f042a55975.png)

Τέλος, δοκιμάσαμε να δούμε αν λειτουργούν σωστά οι εντολές ταξινόμησης πίνακα. Εδώ για φθίνουσα ταξινόμηση.
![Screenshot_12](https://user-images.githubusercontent.com/61273108/220191214-51740a02-8c0e-49ec-b5b4-57a1f6e85f46.png)








